### PR TITLE
Add script to import the codebase into IntelliJ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 *.jar
 plugins/cody-chat/resources/cody-webviews/
+build.scala
+.bsp/
+.scala-build/

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build.scala
 .bsp/
 .scala-build/
 .idea/
+eclipse-plugins-directory.txt

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ plugins/cody-chat/resources/cody-webviews/
 build.scala
 .bsp/
 .scala-build/
+.idea/

--- a/plugins/cody-chat/src/com/sourcegraph/cody/chat/ChatView.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/chat/ChatView.java
@@ -24,7 +24,7 @@ public class ChatView extends ViewPart {
 	public void createPartControl(Composite parent) {
 		var browser = new Browser(parent, SWT.EDGE);
 		browser.setText(loadIndex());
-		
+
 		new BrowserFunction(browser, "postMessage") {
 			@Override
 			public Object function(Object[] arguments) {

--- a/scripts/bsp-project.py
+++ b/scripts/bsp-project.py
@@ -1,23 +1,38 @@
 import os
-import shutil
 import sys
+
 
 def append_to_build_scala(file_path, build_scala):
     if file_path.endswith("-sources.jar"):
-        build_scala.write(f'//> using sourceJar {file_path}\n')
+        build_scala.write(f"//> using sourceJar {file_path}\n")
     else:
-        build_scala.write(f'//> using jar {file_path}\n')
+        build_scala.write(f"//> using jar {file_path}\n")
+
 
 def main():
     build_scala_path = "build.scala"
-    eclipse_plugins_dir = os.path.realpath(os.getenv('ECLIPSE_PLUGINS', '/Applications/Eclipse.app/Contents/Eclipse/plugins/'))
+    eclipse_plugin_config_path = os.path.join(
+        os.path.dirname(__file__), "eclipse-plugins-directory.txt"
+    )
+    if not os.path.isfile(eclipse_plugin_config_path):
+        print(
+            f"Error: File {eclipse_plugin_config_path} does not exist. "
+            + "To fix this problem, create the file and write the absolute file "
+            + "path to your Eclipse installation. On macOS, this path is something like "
+            + "/Applications/Eclipse.app/Contents/plugins",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    with open(eclipse_plugin_config_path, "r") as f:
+        eclipse_plugins_dir = f.read().strip()
 
     if not os.path.isdir(eclipse_plugins_dir):
         print(f"Error: Directory {eclipse_plugins_dir} does not exist", file=sys.stderr)
         sys.exit(1)
 
-    with open(build_scala_path, 'w') as build_scala:
-        build_scala.write('//> using files plugins/cody-chat/src\n')
+    with open(build_scala_path, "w") as build_scala:
+        build_scala.write("//> using files plugins/cody-chat/src\n")
 
         for file in os.listdir(eclipse_plugins_dir):
             file_path = os.path.join(eclipse_plugins_dir, file)
@@ -31,7 +46,12 @@ def main():
                 append_to_build_scala(file_path, build_scala)
 
     os.system("scala-cli setup-ide build.scala")
-    print("Done. Import the project in IntelliJ IDEA. Make sure you have installed the Scala plugin.")
+    print(
+        "Done. Import the project in IntelliJ IDEA via BSP. "
+        + "Make sure you have installed the Scala plugin. "
+        + "Docs: https://www.jetbrains.com/help/idea/bsp-support.html"
+    )
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/bsp-project.py
+++ b/scripts/bsp-project.py
@@ -1,0 +1,37 @@
+import os
+import shutil
+import sys
+
+def append_to_build_scala(file_path, build_scala):
+    if file_path.endswith("-sources.jar"):
+        build_scala.write(f'//> using sourceJar {file_path}\n')
+    else:
+        build_scala.write(f'//> using jar {file_path}\n')
+
+def main():
+    build_scala_path = "build.scala"
+    eclipse_plugins_dir = os.path.realpath(os.getenv('ECLIPSE_PLUGINS', '/Applications/Eclipse.app/Contents/Eclipse/plugins/'))
+
+    if not os.path.isdir(eclipse_plugins_dir):
+        print(f"Error: Directory {eclipse_plugins_dir} does not exist", file=sys.stderr)
+        sys.exit(1)
+
+    with open(build_scala_path, 'w') as build_scala:
+        build_scala.write('//> using files plugins/cody-chat/src\n')
+
+        for file in os.listdir(eclipse_plugins_dir):
+            file_path = os.path.join(eclipse_plugins_dir, file)
+            if file_path.endswith(".source_"):
+                without_source = file_path.replace(".source", "")
+                new_path = without_source.replace(".jar", "-sources.jar")
+                print(new_path)
+                os.symlink(file_path, new_path)
+                append_to_build_scala(new_path, build_scala)
+            else:
+                append_to_build_scala(file_path, build_scala)
+
+    os.system("scala-cli setup-ide build.scala")
+    print("Done. Import the project in IntelliJ IDEA. Make sure you have installed the Scala plugin.")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate-bsp-project-for-intellij.sh
+++ b/scripts/generate-bsp-project-for-intellij.sh
@@ -23,6 +23,12 @@ append_to_build_scala() {
 
 DIR=$(realpath ${ECLIPSE_PLUGINS:-/Applications/Eclipse.app/Contents/Eclipse/plugins/})
 
+if [ ! -d "$DIR" ]; then
+  echo "Error: Directory $DIR does not exist" >&2
+  exit 1
+fi
+
+
 for file in $DIR/*; do
   if [[ $file == *.source_* ]]; then
     without_source="${file/.source/}"
@@ -33,14 +39,6 @@ for file in $DIR/*; do
   else
     append_to_build_scala "$file"
   fi
-done
-
-for file in $(cs fetch org.eclipse.lsp4j:org.eclipse.lsp4j:0.23.1 --classifier sources); do
-  append_to_build_scala "$file"
-done
-
-for file in $(cs fetch org.eclipse.lsp4j:org.eclipse.lsp4j:0.23.1); do
-  append_to_build_scala "$file"
 done
 
 scala-cli setup-ide build.scala

--- a/scripts/generate-bsp-project-for-intellij.sh
+++ b/scripts/generate-bsp-project-for-intellij.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Run this script to generate a scala-cli project for the Eclipse plugin
+# More information about scala-cli https://scala-cli.virtuslab.org/
+# The purpose of this script:
+# - You can import the project into IntelliJ IDEA by using the BSP support from the Scala plugin https://www.jetbrains.com/help/idea/bsp-support.html
+#   However, note that error highlighting doesn't seem to work for Java files.
+# - You can compile the codebase super quickly locally with `scala-cli compile build.scala`
+
+
+
+set -eu
+rm -f build.scala
+
+echo "//> using files plugins/cody-chat/src" >> build.scala
+
+append_to_build_scala() {
+  if [[ $1 == *-sources.jar ]]; then
+    echo "//> using sourceJar \"$1\"" >> build.scala
+  else
+    echo "//> using jar \"$1\"" >> build.scala    
+  fi
+}
+
+DIR=$(realpath ${ECLIPSE_PLUGINS:-/Applications/Eclipse.app/Contents/Eclipse/plugins/})
+
+for file in $DIR/*; do
+  if [[ $file == *.source_* ]]; then
+    without_source="${file/.source/}"
+    new_path="${without_source/.jar/}-sources.jar"
+    echo $new_path
+    ln -svf "$file" "$new_path"
+    append_to_build_scala "$new_path"
+  else
+    append_to_build_scala "$file"
+  fi
+done
+
+for file in $(cs fetch org.eclipse.lsp4j:org.eclipse.lsp4j:0.23.1 --classifier sources); do
+  append_to_build_scala "$file"
+done
+
+for file in $(cs fetch org.eclipse.lsp4j:org.eclipse.lsp4j:0.23.1); do
+  append_to_build_scala "$file"
+done
+
+scala-cli setup-ide build.scala
+echo "Done. Import the project in IntelliJ IDEA. Make sure you have installed the Scala plugin."


### PR DESCRIPTION
Previously, the only way to edit the Java code in the project was to use Eclipse. This PR adds a script to generate a build for the `scala-cli` tool that we can import into IntelliJ using BSP. See the comments in the script for more details.

Fixes CODY-2250


## Test plan
* Follow the steps in the script
* Import into IntelliJ
* Confirm you have autocomplete and goto-definition
* Note that error highlighting does not work 😢  (yet)

![CleanShot 2024-06-11 at 15 10 41@2x](https://github.com/sourcegraph/eclipse/assets/1408093/31850365-bf62-43a0-a16d-929e922494ef)

![CleanShot 2024-06-11 at 15 10 43@2x](https://github.com/sourcegraph/eclipse/assets/1408093/50a970c7-1308-4d4a-8d4a-e31f41188eb3)

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
