### PR TITLE
Add secure storage

### DIFF
--- a/plugins/cody-chat/META-INF/MANIFEST.MF
+++ b/plugins/cody-chat/META-INF/MANIFEST.MF
@@ -9,7 +9,11 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.jetty.util,
  org.eclipse.jetty.io,
  org.eclipse.jetty.http,
- org.eclipse.ui.ide.application
+ org.eclipse.ui.ide.application,
+ org.eclipse.e4.core.di,
+ org.eclipse.e4.core.di.annotations,
+ org.eclipse.e4.core.contexts,
+ org.eclipse.equinox.security
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Import-Package: jakarta.inject;version="[2.0.0,3.0.0)"
 Automatic-Module-Name: cody.chat

--- a/plugins/cody-chat/resources/index.html
+++ b/plugins/cody-chat/resources/index.html
@@ -7,27 +7,27 @@
     <script>
       function receiveMessage(message) {
 	    const reply = document.createElement("p");
-	    reply.innerHTML = message;
+	    reply.innerHTML = `${message} (token: ${getToken()})`;
 	    document.body.appendChild(reply);
       }
       console.log = function(message) {
-        postMessage(JSON.stringify({kind: 'log', message}))
+		logInEclipse(JSON.stringify({kind: 'log', message}))
       };
       console.warn = function(message) {
-        postMessage(JSON.stringify({kind: 'warn', message}))
+		logInEclipse(JSON.stringify({kind: 'warn', message}))
       };
       console.error = function(message) {
-        postMessage(JSON.stringify({kind: 'error', message}))
+		logInEclipse(JSON.stringify({kind: 'error', message}))
       };
       window.onerror = function(message, source, lineno, colno, error) {
-        postMessage(JSON.stringify({kind: 'onerror', message, source, lineno, colno, error}))
+		logInEclipse(JSON.stringify({kind: 'onerror', message, source, lineno, colno, error}))
       };
 	  
       function handleSubmit(event) {
         event.preventDefault();
         const input = document.getElementById("userInput").value;
         postMessage(input);
-        console.log("User input:", input);
+        console.log("User input: " + input);
       }
     </script>
   </head>

--- a/plugins/cody-chat/src/com/sourcegraph/cody/chat/access/LogInJob.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/chat/access/LogInJob.java
@@ -1,7 +1,5 @@
 package com.sourcegraph.cody.chat.access;
 
-import static java.lang.System.out;
-
 import java.util.Optional;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
@@ -11,6 +9,8 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.e4.core.contexts.ContextInjectionFactory;
+import org.eclipse.e4.core.contexts.IEclipseContext;
 import org.eclipse.jetty.http.HttpURI;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
@@ -20,15 +20,28 @@ import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.swt.program.Program;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
+
+import jakarta.inject.Inject;
 
 public class LogInJob extends Job {
 
 	private static final String LOG_IN_URL = "https://sourcegraph.com/user/settings/tokens/new/callback?requestFrom=JETBRAINS-";
 
 	private WaitingForLoginWindow window = null;
+	
+	@Inject
+	private TokenStorage tokenStorage;
+	
+	@Inject
+	private Display display;
 
-	public LogInJob() {
+	@Inject
+	private Shell shell;
+
+	public LogInJob(IEclipseContext context) {
 		super("Loging in...");
+		ContextInjectionFactory.inject(this, context);
 	}
 
 	@Override
@@ -63,13 +76,13 @@ public class LogInJob extends Job {
 			// open login page
 
 			var url = LOG_IN_URL + port;
-			Display.getDefault().asyncExec(() -> {
+			display.asyncExec(() -> {
 				Program.launch(url);
 			});
 
 			// wait for response
 			var response = tokenSignal.get();
-			out.println("!!! " + response);
+			tokenStorage.put(response);
 
 			return Status.OK_STATUS;
 		} catch (CancellationException e) {
@@ -88,9 +101,9 @@ public class LogInJob extends Job {
 	}
 
 	private void showWindow(CompletableFuture<String> tokenSignal) {
-		Display.getDefault().asyncExec(() -> {
+		display.asyncExec(() -> {
 			window = new WaitingForLoginWindow(
-					Display.getDefault().getActiveShell(),
+					shell,
 					() -> { tokenSignal.cancel(true); }
 			);
 			window.open();
@@ -98,7 +111,7 @@ public class LogInJob extends Job {
 	}
 
 	private void closeWindow() {
-		Display.getDefault().asyncExec(() -> {
+		display.asyncExec(() -> {
 			if (window != null) {
 				window.close();
 			}

--- a/plugins/cody-chat/src/com/sourcegraph/cody/chat/access/TokenStorage.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/chat/access/TokenStorage.java
@@ -1,0 +1,33 @@
+package com.sourcegraph.cody.chat.access;
+
+import org.eclipse.e4.core.di.annotations.Creatable;
+import org.eclipse.equinox.security.storage.ISecurePreferences;
+import org.eclipse.equinox.security.storage.SecurePreferencesFactory;
+import org.eclipse.equinox.security.storage.StorageException;
+
+import java.io.IOException;
+
+import jakarta.inject.Singleton;
+
+@Creatable
+@Singleton
+public class TokenStorage {
+	
+	private static String NODE_ID = "/com/sourcegraph/cody/chat";
+	private static String KEY = "token";
+	
+	private ISecurePreferences preferences = SecurePreferencesFactory.getDefault().node(NODE_ID);
+	
+	public void put(String token) throws StorageException, IOException {
+		preferences.put(KEY, token, true);
+		preferences.flush();
+	}
+	
+	public String get() throws StorageException {
+		return preferences.get(KEY, "");
+	}
+	
+	public void remove() {
+		preferences.remove(KEY);
+	}
+}


### PR DESCRIPTION
Previously, we didn't store the access token after authenticating with GitHub. This PR changes the post-authentication behavior so that we storethe access token in a secret storage so that users don't have to re-authenticate on every restart.

Fixes CODY-2164

## Test plan

Tested manually on Linux. After loggign in, the token is stored encrypted in `~/.eclipse/org.eclipse.equinox.security/secure_storage`. The system is managing the encryption key so it should be impossible to read the token as any other user. Sending any message through the webview shows that it has access to the token.

Requires testing on windows. The secure storage should be located in `%USERPROFILE%`.