### PR TITLE
Support multiple tokens and custom logging urls

### DIFF
--- a/plugins/cody-chat/plugin.xml
+++ b/plugins/cody-chat/plugin.xml
@@ -16,6 +16,14 @@
             category="cody"
             inject="true">
       </view>
+      <view
+            category="cody"
+            class="com.sourcegraph.cody.chat.access.TokenSelectionView"
+            icon="icons/sample.png"
+            id="com.sourcegraph.cody.chat.access.TokenSelectionView"
+            inject="true"
+            name="Cody token selection">
+      </view>
    </extension>
    <extension
          point="org.eclipse.ui.perspectiveExtensions">

--- a/plugins/cody-chat/src/com/sourcegraph/cody/chat/access/LogInJob.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/chat/access/LogInJob.java
@@ -5,7 +5,6 @@ import java.util.Optional;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.regex.Pattern;
-
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
@@ -22,8 +21,6 @@ import org.eclipse.jetty.util.Callback;
 import org.eclipse.swt.program.Program;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
-
-import jakarta.inject.Inject;
 
 public class LogInJob extends Job {
 

--- a/plugins/cody-chat/src/com/sourcegraph/cody/chat/access/NewTokenDialog.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/chat/access/NewTokenDialog.java
@@ -1,0 +1,68 @@
+package com.sourcegraph.cody.chat.access;
+
+import com.sourcegraph.cody.chat.access.TokenStorage.Profile;
+import java.util.Optional;
+import org.eclipse.jface.dialogs.Dialog;
+import org.eclipse.jface.window.Window;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.swt.widgets.Text;
+
+public class NewTokenDialog extends Dialog {
+
+  private Text nameText;
+  private Text urlText;
+
+  private String name;
+  private String url;
+
+  private NewTokenDialog(Shell parentShell) {
+    super(parentShell);
+  }
+
+  @Override
+  protected Control createDialogArea(Composite parent) {
+    var composite = new Composite(parent, SWT.NONE);
+    composite.setLayout(new GridLayout(2, false));
+
+    Label nameLabel = new Label(composite, SWT.NONE);
+    nameLabel.setText("Name");
+    nameText = new Text(composite, SWT.BORDER);
+    var nameLayout = new GridData();
+    nameLayout.grabExcessHorizontalSpace = true;
+    nameLayout.horizontalAlignment = GridData.FILL;
+    nameText.setLayoutData(nameLayout);
+
+    Label urlLabel = new Label(composite, SWT.NONE);
+    urlLabel.setText("URL");
+    urlText = new Text(composite, SWT.BORDER);
+    var urlLayout = new GridData();
+    urlLayout.grabExcessHorizontalSpace = true;
+    urlLayout.horizontalAlignment = GridData.FILL;
+    urlText.setLayoutData(urlLayout);
+    urlText.setText(TokenSelectionView.DEFAULT_URL);
+
+    return composite;
+  }
+
+  @Override
+  protected void okPressed() {
+    name = nameText.getText();
+    url = urlText.getText();
+    super.okPressed();
+  }
+
+  static Optional<Profile> ask(Shell shell) {
+    var dialog = new NewTokenDialog(shell);
+    if (dialog.open() == Window.OK) {
+      return Optional.of(new Profile(dialog.name, dialog.url));
+    } else {
+      return Optional.empty();
+    }
+  }
+}

--- a/plugins/cody-chat/src/com/sourcegraph/cody/chat/access/TokenSelectionView.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/chat/access/TokenSelectionView.java
@@ -1,0 +1,163 @@
+package com.sourcegraph.cody.chat.access;
+
+import com.sourcegraph.cody.chat.access.TokenStorage.Profile;
+import jakarta.inject.Inject;
+import java.util.List;
+import org.eclipse.e4.core.contexts.IEclipseContext;
+import org.eclipse.jface.action.Action;
+import org.eclipse.jface.action.IToolBarManager;
+import org.eclipse.jface.viewers.DoubleClickEvent;
+import org.eclipse.jface.viewers.IDoubleClickListener;
+import org.eclipse.jface.viewers.IStructuredContentProvider;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.viewers.ITableLabelProvider;
+import org.eclipse.jface.viewers.LabelProvider;
+import org.eclipse.jface.viewers.TableViewer;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.IActionBars;
+import org.eclipse.ui.ISharedImages;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.part.ViewPart;
+
+public class TokenSelectionView extends ViewPart {
+
+  public static final String ID = "com.sourcegraph.cody.chat.access.TokenSelectionView";
+
+  public static final String DEFAULT_URL =
+      "https://sourcegraph.com/user/settings/tokens/new/callback";
+
+  @Inject IWorkbench workbench;
+
+  @Inject TokenStorage tokenStorage;
+
+  @Inject Display display;
+
+  @Inject IEclipseContext context;
+
+  @Inject Shell shell;
+
+  private TableViewer viewer;
+  private Action removeAction;
+  private Action addAction;
+  private Action doubleClickAction;
+
+  class ViewLabelProvider extends LabelProvider implements ITableLabelProvider {
+    @Override
+    public String getColumnText(Object obj, int index) {
+      var profile = (Profile) obj;
+      return profile.name + " (" + profile.url + ")";
+    }
+
+    @Override
+    public Image getColumnImage(Object obj, int index) {
+      return getImage(obj);
+    }
+
+    @Override
+    public Image getImage(Object obj) {
+      var profile = (Profile) obj;
+      if (profile.name == tokenStorage.getActiveProfileName().orElse(null)) {
+        return workbench.getSharedImages().getImage(ISharedImages.IMG_OBJ_ELEMENT);
+      } else {
+        return null;
+      }
+    }
+  }
+
+  @Override
+  public void createPartControl(Composite parent) {
+    viewer = new TableViewer(parent, SWT.H_SCROLL | SWT.V_SCROLL);
+
+    viewer.setContentProvider(
+        new IStructuredContentProvider() {
+          @SuppressWarnings("unchecked")
+          @Override
+          public Object[] getElements(Object inputElement) {
+            return ((List<Profile>) inputElement).toArray();
+          }
+        });
+    viewer.setInput(tokenStorage.getAllProfiless());
+    viewer.setLabelProvider(new ViewLabelProvider());
+    getSite().setSelectionProvider(viewer);
+    makeActions();
+    hookDoubleClickAction();
+    contributeToActionBars();
+    tokenStorage.addCallback(
+        () -> {
+          display.asyncExec(
+              () -> {
+                viewer.setInput(tokenStorage.getAllProfiless());
+              });
+        });
+  }
+
+  private void contributeToActionBars() {
+    IActionBars bars = getViewSite().getActionBars();
+    fillLocalToolBar(bars.getToolBarManager());
+  }
+
+  private void fillLocalToolBar(IToolBarManager manager) {
+    manager.add(addAction);
+    manager.add(removeAction);
+  }
+
+  private void makeActions() {
+    removeAction =
+        new Action() {
+          public void run() {
+            var selection = viewer.getStructuredSelection().getFirstElement();
+            if (selection instanceof Profile) {
+              tokenStorage.remove(((Profile) selection).name);
+            }
+          }
+        };
+    removeAction.setText("Remove");
+    removeAction.setToolTipText("Remove profile");
+    removeAction.setImageDescriptor(
+        PlatformUI.getWorkbench()
+            .getSharedImages()
+            .getImageDescriptor(ISharedImages.IMG_ETOOL_DELETE));
+
+    addAction =
+        new Action() {
+          public void run() {
+            var profile = NewTokenDialog.ask(shell);
+            if (profile.isPresent()) {
+              new LogInJob(context, profile.get().name, profile.get().url).schedule();
+            }
+          }
+        };
+    addAction.setText("Add");
+    addAction.setToolTipText("Add");
+    addAction.setImageDescriptor(
+        workbench.getSharedImages().getImageDescriptor(ISharedImages.IMG_OBJ_ADD));
+
+    doubleClickAction =
+        new Action() {
+          public void run() {
+            IStructuredSelection selection = viewer.getStructuredSelection();
+            var profile = (Profile) selection.getFirstElement();
+            tokenStorage.setActiveProfileName(profile.name);
+          }
+        };
+  }
+
+  private void hookDoubleClickAction() {
+    viewer.addDoubleClickListener(
+        new IDoubleClickListener() {
+          public void doubleClick(DoubleClickEvent event) {
+            doubleClickAction.run();
+          }
+        });
+  }
+
+  @Override
+  public void setFocus() {
+    viewer.getControl().setFocus();
+  }
+}

--- a/plugins/cody-chat/src/com/sourcegraph/cody/chat/access/TokenStorage.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/chat/access/TokenStorage.java
@@ -2,30 +2,148 @@ package com.sourcegraph.cody.chat.access;
 
 import jakarta.inject.Singleton;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences.INodeChangeListener;
+import org.eclipse.core.runtime.preferences.IEclipsePreferences.NodeChangeEvent;
+import org.eclipse.core.runtime.preferences.InstanceScope;
 import org.eclipse.e4.core.di.annotations.Creatable;
+import org.eclipse.equinox.security.storage.EncodingUtils;
 import org.eclipse.equinox.security.storage.ISecurePreferences;
 import org.eclipse.equinox.security.storage.SecurePreferencesFactory;
 import org.eclipse.equinox.security.storage.StorageException;
+import org.osgi.service.prefs.BackingStoreException;
 
 @Creatable
 @Singleton
 public class TokenStorage {
 
-  private static String NODE_ID = "/com/sourcegraph/cody/chat";
-  private static String KEY = "token";
+  public static class Profile {
+    public final String name;
+    public final String url;
 
-  private ISecurePreferences preferences = SecurePreferencesFactory.getDefault().node(NODE_ID);
-
-  public void put(String token) throws StorageException, IOException {
-    preferences.put(KEY, token, true);
-    preferences.flush();
+    public Profile(String name, String url) {
+      this.name = name;
+      this.url = url;
+    }
   }
 
-  public String get() throws StorageException {
-    return preferences.get(KEY, "");
+  private static String SECURE_NODE_ID = "/com/sourcegraph/cody/chat/tokens";
+  private static String SETTING_NODE_ID =
+      "cody-chat/tokens"; // Path for settings node should start with a plugin ID
+  private static String PROFILES_NODE_ID = SETTING_NODE_ID + "/profiles";
+
+  private ISecurePreferences secureStorage =
+      SecurePreferencesFactory.getDefault().node(SECURE_NODE_ID);
+  private IEclipsePreferences settingsStorage = InstanceScope.INSTANCE.getNode(SETTING_NODE_ID);
+  private IEclipsePreferences profileStorage = InstanceScope.INSTANCE.getNode(PROFILES_NODE_ID);
+  // Profiles are associated with a workspace. To associate them with Eclipse
+  // installation change `InstanceScope` to `ConfigurationScope`.
+
+  private String activeProfile = null;
+
+  public List<Profile> getAllProfiless() {
+    List<Profile> result = new ArrayList<>();
+    try {
+      profileStorage.accept(
+          (node) -> {
+            if (node.absolutePath().endsWith(PROFILES_NODE_ID)) {
+              return true;
+            } else {
+              result.add(new Profile(node.get("name", null), node.get("url", null)));
+              return false;
+            }
+          });
+    } catch (BackingStoreException e) {
+      throw new RuntimeException(e); // Escalating unlikely exception
+    }
+    return result;
   }
 
-  public void remove() {
-    preferences.remove(KEY);
+  public void addCallback(Runnable callback) {
+    profileStorage.addNodeChangeListener(
+        new INodeChangeListener() {
+          @Override
+          public void added(NodeChangeEvent event) {
+            callback.run();
+          }
+
+          @Override
+          public void removed(NodeChangeEvent event) {
+            callback.run();
+          }
+        });
+    settingsStorage.addPreferenceChangeListener(
+        event -> {
+          callback.run();
+        });
+  }
+
+  public void put(String name, String url, String token) {
+    var id = safeID(name);
+    var node = profileStorage.node(id);
+    node.put("name", name);
+    node.put("url", url);
+
+    try {
+      secureStorage.put(id, token, true);
+      profileStorage.flush();
+      secureStorage.flush();
+    } catch (StorageException | BackingStoreException | IOException e) {
+      throw new RuntimeException(e); // Escalating unlikely exceptions
+    }
+  }
+
+  public String getToken(String name) {
+    try {
+      String id = safeID(name);
+      return secureStorage.get(id, "");
+    } catch (StorageException e) {
+      throw new RuntimeException(e); // Escalating unlikely exception
+    }
+  }
+
+  public void setActiveProfileName(String name) {
+    activeProfile = name;
+    settingsStorage.put("last", name);
+    try {
+      settingsStorage.flush();
+    } catch (BackingStoreException e) {
+      throw new RuntimeException(e); // Escalating unlikely exception
+    }
+  }
+
+  public Optional<String> getActiveProfileName() {
+    if (activeProfile == null) {
+      try {
+        var fromPreviousSession = settingsStorage.get("last", null);
+        if (fromPreviousSession != null && profileStorage.nodeExists(safeID(fromPreviousSession))) {
+          activeProfile = fromPreviousSession;
+        }
+      } catch (BackingStoreException e) {
+        throw new RuntimeException(e); // Escalating unlikely exception
+      }
+    }
+    return Optional.ofNullable(activeProfile);
+  }
+
+  public void remove(String name) {
+    var id = safeID(name);
+    try {
+      profileStorage.node(id).removeNode();
+      secureStorage.remove(id);
+      profileStorage.flush();
+      secureStorage.flush();
+    } catch (BackingStoreException | IOException e) {
+      throw new RuntimeException(e); // Escalating unlikely exception
+    }
+  }
+
+  private String safeID(String name) {
+    // Node ids in secure storage can only contain ASCII chars
+    // from open ranges (32, 47) and (47, 126).
+    return EncodingUtils.encodeSlashes(EncodingUtils.encodeBase64(name.getBytes()));
   }
 }

--- a/plugins/cody-chat/src/com/sourcegraph/cody/protocol_generated/EditTask.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/protocol_generated/EditTask.java
@@ -9,4 +9,3 @@ public final class EditTask {
   public Range selectionRange;
   public String instruction;
 }
-

--- a/plugins/cody-chat/src/com/sourcegraph/cody/protocol_generated/EditTask.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/protocol_generated/EditTask.java
@@ -9,3 +9,4 @@ public final class EditTask {
   public Range selectionRange;
   public String instruction;
 }
+


### PR DESCRIPTION
Before we can only use one token at any given moment. After this PR multiple tokens coming from different urls can be stored at the same time. We can select active token that can be used for chat.

## Test plan
Tested manually. Clicking the button i upper right corner of chat view opens a new view. In that view we can get new tokens and remove existing ones. Double clicking a token marks it as active. Active token can be seen after submitting anything in the chat view.
