### PR TITLE
Remove Cody submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "cody"]
-	path = cody
-	url = https://github.com/sourcegraph/cody

--- a/scripts/build-webview.sh
+++ b/scripts/build-webview.sh
@@ -1,10 +1,9 @@
 #!/bin/bash
 set -eux
-git submodule update --init --recursive
-pushd cody
+pushd ../cody
 pnpm dlx pnpm@8.6.7 install
 pnpm dlx pnpm@8.6.7 build
 pnpm dlx pnpm@8.6.7 -C vscode build
 popd
 mkdir -p plugins/cody-chat/resources/cody-webviews
-cp cody/vscode/dist/webviews/* plugins/cody-chat/resources/cody-webviews
+cp ../cody/vscode/dist/webviews/* plugins/cody-chat/resources/cody-webviews


### PR DESCRIPTION
Eclipse started freezing during startup after I ran `pnpm install` in the cody submodule. This PR removes the submodule in favor of requiring contributors to clone the Cody repo as a sibling directory. This makes Eclipse boot up quickly again.

## Test plan

Boot up Eclipse and it doesn't freeze anymore.
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
