### PR TITLE
Implement adding code at the cursor position

### DIFF
--- a/plugins/cody-chat/META-INF/MANIFEST.MF
+++ b/plugins/cody-chat/META-INF/MANIFEST.MF
@@ -19,7 +19,9 @@ Require-Bundle: org.eclipse.core.runtime,
  com.google.gson,
  org.eclipse.lsp4j.jsonrpc,
  org.eclipse.ui.ide,
- org.eclipse.core.resources
+ org.eclipse.core.resources,
+ org.eclipse.ui.editors,
+ org.eclipse.jface.text
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ClassPath: .,lib/directories-26.jar
 Import-Package: jakarta.inject;version="[2.0.0,3.0.0)"

--- a/plugins/cody-chat/plugin.xml
+++ b/plugins/cody-chat/plugin.xml
@@ -45,6 +45,10 @@
             implementation="com.sourcegraph.cody.handlers.NewFileHandler"
             message="com.sourcegraph.cody.protocol_generated.WebviewMessage$NewFileWebviewMessage">
       </handler>
+      <handler
+            implementation="com.sourcegraph.cody.handlers.InsertHandler"
+            message="com.sourcegraph.cody.protocol_generated.WebviewMessage$InsertWebviewMessage">
+      </handler>
    </extension>
 
 </plugin>

--- a/plugins/cody-chat/resources/injected-script.js
+++ b/plugins/cody-chat/resources/injected-script.js
@@ -29,9 +29,15 @@ globalThis.acquireVsCodeApi = (function () {
         if (message?.command === "initialized") {
           eclipse_initialized(true);
         }
-        // console.log(`do-post-message: ${JSON.stringify(message)}`);
-        eclipse_receiveMessage(JSON.stringify(message));
-        //   ${viewToHost.inject("JSON.stringify({what: 'postMessage', value: message})")}
+
+        switch (message?.command) {
+          case 'insert':
+          case 'newFile':
+            eclipse_interceptMessage(JSON.stringify(message));
+            break;
+          default:
+            eclipse_receiveMessage(JSON.stringify(message));
+        }
       },
       setState: function (newState) {
         state = newState;

--- a/plugins/cody-chat/src/com/sourcegraph/cody/chat/ChatView.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/chat/ChatView.java
@@ -186,6 +186,14 @@ public class ChatView extends ViewPart {
       return;
     }
 
+    new BrowserFunction(browser, "eclipse_initialized") {
+      @Override
+      public Object function(Object[] arguments) {
+        webviewInitialized.complete(true);
+        return null;
+      }
+    };
+
     // Most webview messages are proxied directly to the Cody Agent.
     // We only intercept a small number of messages for features are easier
     // to implement directly in Eclipse instead of wiring through the agent

--- a/plugins/cody-chat/src/com/sourcegraph/cody/handlers/InsertHandler.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/handlers/InsertHandler.java
@@ -1,0 +1,25 @@
+package com.sourcegraph.cody.handlers;
+
+import com.sourcegraph.cody.protocol_generated.WebviewMessage;
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.ITextSelection;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.texteditor.AbstractTextEditor;
+
+public class InsertHandler implements MessageHandler<WebviewMessage.InsertWebviewMessage> {
+
+  @Override
+  public void doHandle(WebviewMessage.InsertWebviewMessage message) {
+    var maybeEditor =
+        PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().getActiveEditor();
+    if (!(maybeEditor instanceof AbstractTextEditor)) return;
+    var editor = (AbstractTextEditor) maybeEditor;
+    var selection = (ITextSelection) editor.getSelectionProvider().getSelection();
+    var document = editor.getDocumentProvider().getDocument(editor.getEditorInput());
+    try {
+      document.replace(selection.getOffset(), selection.getLength(), message.text);
+    } catch (BadLocationException e) {
+      e.printStackTrace();
+    }
+  }
+}


### PR DESCRIPTION
Up until now, trying to insert snippet from cody chat to existing file resulted in exception. Now it works.

## Test plan

Ask cody to generate some code. Click `Insert Code at Cursor...` button. The code should be inserted at the cursor position in the active editor. If no editor is open the action shouldn't do anything.

Eclipse in its editor api doesn't distinguish between selection and cursor position. Cursor is just a selection with length 0. Because of that, when we are inserting a snippet, when some text is selected, this text will be replaced. We can easily change that, so the generated snippet is inserted either before or after the selection.

