### PR TITLE
Document synchronization: implement basic support

### DIFF
--- a/plugins/cody-chat/META-INF/MANIFEST.MF
+++ b/plugins/cody-chat/META-INF/MANIFEST.MF
@@ -26,3 +26,5 @@ Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ClassPath: .,lib/directories-26.jar
 Import-Package: jakarta.inject;version="[2.0.0,3.0.0)"
 Automatic-Module-Name: cody.chat
+Bundle-ActivationPolicy: lazy
+Bundle-Activator: com.sourcegraph.cody.CodyChatActivator

--- a/plugins/cody-chat/src/com/sourcegraph/cody/CodyAgent.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/CodyAgent.java
@@ -1,11 +1,9 @@
 package com.sourcegraph.cody;
 
 import com.google.gson.GsonBuilder;
-import com.sourcegraph.cody.protocol_generated.ClientCapabilities;
-import com.sourcegraph.cody.protocol_generated.ClientInfo;
-import com.sourcegraph.cody.protocol_generated.CodyAgentServer;
-import com.sourcegraph.cody.protocol_generated.ExtensionConfiguration;
-import com.sourcegraph.cody.protocol_generated.ProtocolTypeAdapters;
+import com.sourcegraph.cody.protocol_generated.*;
+import com.sourcegraph.cody.workspace.EditorState;
+import com.sourcegraph.cody.workspace.WorkspaceListener;
 import dev.dirs.ProjectDirectories;
 import java.io.File;
 import java.io.IOException;
@@ -24,9 +22,12 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Consumer;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.lsp4j.jsonrpc.Launcher;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.services.IDisposable;
 
 // @Creatable
@@ -206,7 +207,12 @@ public class CodyAgent implements IDisposable {
     Future<Void> listening = launcher.startListening();
     CodyAgentServer server = launcher.getRemoteProxy();
     initialize(server, workspaceRoot);
-    return new CodyAgent(listening, server, process);
+
+    var instance = new CodyAgent(listening, server, process);
+    instance.discoverWorkbenchState();
+
+    AGENT = instance;
+    return instance;
   }
 
   public static void configureGson(GsonBuilder builder) {
@@ -267,6 +273,81 @@ public class CodyAgent implements IDisposable {
     clientInfo.extensionConfiguration = CodyAgent.config;
     server.initialize(clientInfo).get(20, TimeUnit.SECONDS);
     server.initialized(null);
+  }
+
+  private void discoverWorkbenchState() {
+    // This can cause UI to hang for a moment after the start of the agent. If that's a problem,
+    // split this function into two parts: collecting the state and then notifying the agent. Run
+    // the first part with Display.syncExec.
+    Display.getDefault()
+        .asyncExec(
+            () -> {
+              var editors =
+                  PlatformUI.getWorkbench()
+                      .getActiveWorkbenchWindow()
+                      .getActivePage()
+                      .getEditorReferences();
+
+              for (var editor : editors) {
+                var editorState = EditorState.from(editor);
+                if (editorState != null) {
+                  fileOpened(editorState);
+                }
+              }
+
+              var activeEditor =
+                  PlatformUI.getWorkbench()
+                      .getActiveWorkbenchWindow()
+                      .getActivePage()
+                      .getActivePartReference();
+
+              var activeEditorState = EditorState.from(activeEditor);
+              if (activeEditorState != null) {
+                focusChanged(activeEditorState);
+
+                // TODO: Refactor this.
+                WorkspaceListener.setupSelectionListener(activeEditorState);
+                WorkspaceListener.setupContentListener(activeEditorState);
+              }
+            });
+  }
+
+  ////////////////////
+  // NOTIFICATIONS //
+  ///////////////////
+
+  public void focusChanged(EditorState state) {
+    var params = new TextDocument_DidFocusParams();
+    params.uri = state.uri;
+    server.textDocument_didFocus(params);
+  }
+
+  public void fileOpened(EditorState state) {
+    var params = new ProtocolTextDocument();
+    params.uri = state.uri;
+    params.content = state.readContents();
+    server.textDocument_didOpen(params);
+  }
+
+  public void selectionChanged(EditorState state, Range range) {
+    var params = new ProtocolTextDocument();
+    params.uri = state.uri;
+    params.selection = range;
+    server.textDocument_didChange(params);
+  }
+
+  public void fileChanged(EditorState state) {
+    var params = new ProtocolTextDocument();
+    params.uri = state.uri;
+    params.content = state.readContents();
+    server.textDocument_didChange(params);
+  }
+
+  public static void withAgent(Consumer<CodyAgent> callback) {
+    var agent = CodyAgent.AGENT;
+    if (agent != null && agent.isRunning()) {
+      callback.accept(agent);
+    }
   }
 
   private static PrintWriter traceWriter() {

--- a/plugins/cody-chat/src/com/sourcegraph/cody/CodyChatActivator.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/CodyChatActivator.java
@@ -1,0 +1,40 @@
+package com.sourcegraph.cody;
+
+import static java.lang.System.out;
+
+import com.sourcegraph.cody.workspace.WorkspaceListener;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.ui.IPartListener2;
+import org.eclipse.ui.IWorkbenchPartReference;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.plugin.AbstractUIPlugin;
+import org.osgi.framework.BundleContext;
+
+public class CodyChatActivator extends AbstractUIPlugin {
+
+  @Override
+  public void start(BundleContext bundleContext) throws Exception {
+    // async exec to make sure the UI is initialized
+    Display.getDefault()
+        .asyncExec(
+            () -> {
+              @Nullable
+              IWorkbenchWindow workbenchWindow =
+                  PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+
+              if (workbenchWindow == null) {
+                System.out.println("No active workbench window");
+                return;
+              }
+
+              var partService = workbenchWindow.getPartService();
+
+              partService.addPartListener(new WorkspaceListener());
+
+              // Uncomment below to debug the workspace listener.
+              // partService.addPartListener(new DebugListener());
+            });
+  }
+}

--- a/plugins/cody-chat/src/com/sourcegraph/cody/CodyChatActivator.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/CodyChatActivator.java
@@ -1,12 +1,8 @@
 package com.sourcegraph.cody;
 
-import static java.lang.System.out;
-
 import com.sourcegraph.cody.workspace.WorkspaceListener;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.swt.widgets.Display;
-import org.eclipse.ui.IPartListener2;
-import org.eclipse.ui.IWorkbenchPartReference;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.plugin.AbstractUIPlugin;

--- a/plugins/cody-chat/src/com/sourcegraph/cody/DebugWorkspaceListener.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/DebugWorkspaceListener.java
@@ -1,0 +1,80 @@
+package com.sourcegraph.cody;
+
+import org.eclipse.ui.IPartListener2;
+import org.eclipse.ui.IWorkbenchPartReference;
+
+import static java.lang.System.out;
+
+class DebugWorkspaceListener implements IPartListener2 {
+  @Override
+  public void partActivated(IWorkbenchPartReference iWorkbenchPartReference) {
+    out.println(
+        "partActivated "
+            + iWorkbenchPartReference.getTitle()
+            + " "
+            + iWorkbenchPartReference.getPart(false));
+  }
+
+  @Override
+  public void partBroughtToTop(IWorkbenchPartReference iWorkbenchPartReference) {
+    out.println(
+        "partBroughtToTop "
+            + iWorkbenchPartReference.getTitle()
+            + " "
+            + iWorkbenchPartReference.getPart(false));
+  }
+
+  @Override
+  public void partClosed(IWorkbenchPartReference iWorkbenchPartReference) {
+    out.println(
+        "partClosed "
+            + iWorkbenchPartReference.getTitle()
+            + " "
+            + iWorkbenchPartReference.getPart(false));
+  }
+
+  @Override
+  public void partDeactivated(IWorkbenchPartReference iWorkbenchPartReference) {
+    out.println(
+        "partDeactivated "
+            + iWorkbenchPartReference.getTitle()
+            + " "
+            + iWorkbenchPartReference.getPart(false));
+  }
+
+  @Override
+  public void partOpened(IWorkbenchPartReference iWorkbenchPartReference) {
+    out.println(
+        "partOpened "
+            + iWorkbenchPartReference.getTitle()
+            + " "
+            + iWorkbenchPartReference.getPart(false));
+  }
+
+  @Override
+  public void partHidden(IWorkbenchPartReference iWorkbenchPartReference) {
+    out.println(
+        "partHidden "
+            + iWorkbenchPartReference.getTitle()
+            + " "
+            + iWorkbenchPartReference.getPart(false));
+  }
+
+  @Override
+  public void partVisible(IWorkbenchPartReference iWorkbenchPartReference) {
+    out.println(
+        "partVisible "
+            + iWorkbenchPartReference.getTitle()
+            + " "
+            + iWorkbenchPartReference.getPart(false));
+  }
+
+  @Override
+  public void partInputChanged(IWorkbenchPartReference iWorkbenchPartReference) {
+    out.println(
+        "partInputChanged "
+            + iWorkbenchPartReference.getTitle()
+            + " "
+            + iWorkbenchPartReference.getPart(false));
+  }
+}

--- a/plugins/cody-chat/src/com/sourcegraph/cody/DebugWorkspaceListener.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/DebugWorkspaceListener.java
@@ -1,9 +1,9 @@
 package com.sourcegraph.cody;
 
+import static java.lang.System.out;
+
 import org.eclipse.ui.IPartListener2;
 import org.eclipse.ui.IWorkbenchPartReference;
-
-import static java.lang.System.out;
 
 class DebugWorkspaceListener implements IPartListener2 {
   @Override

--- a/plugins/cody-chat/src/com/sourcegraph/cody/workspace/EditorState.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/workspace/EditorState.java
@@ -1,0 +1,48 @@
+package com.sourcegraph.cody.workspace;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.ui.IWorkbenchPartReference;
+import org.eclipse.ui.part.FileEditorInput;
+import org.eclipse.ui.texteditor.ITextEditor;
+
+public final class EditorState {
+  public final IFile file;
+  public final String uri;
+  public final ITextEditor editor;
+  @Nullable private IDocument document = null;
+
+  private EditorState(IFile file, String uri, ITextEditor editor) {
+    this.file = file;
+    this.uri = uri;
+    this.editor = editor;
+  }
+
+  public String readContents() {
+    return getDocument().get();
+  }
+
+  public IDocument getDocument() {
+    if (document == null) {
+      document = editor.getDocumentProvider().getDocument(editor.getEditorInput());
+    }
+    return document;
+  }
+
+  @Nullable
+  public static EditorState from(IWorkbenchPartReference partReference) {
+    var part = partReference.getPart(false);
+    if (!(part instanceof ITextEditor)) {
+      return null;
+    }
+    var editor1 = (ITextEditor) part;
+    var input = editor1.getEditorInput();
+    if (!(input instanceof FileEditorInput)) {
+      System.out.println("Unknown input kind: " + input.getClass());
+      return null;
+    }
+    var file1 = ((FileEditorInput) input).getFile();
+    return new EditorState(file1, file1.getLocationURI().toString(), editor1);
+  }
+}

--- a/plugins/cody-chat/src/com/sourcegraph/cody/workspace/WorkspaceListener.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/workspace/WorkspaceListener.java
@@ -1,0 +1,91 @@
+package com.sourcegraph.cody.workspace;
+
+import static com.sourcegraph.cody.CodyAgent.withAgent;
+
+import com.sourcegraph.cody.WrappedRuntimeException;
+import com.sourcegraph.cody.protocol_generated.Position;
+import com.sourcegraph.cody.protocol_generated.Range;
+import org.eclipse.jface.text.*;
+import org.eclipse.ui.IPartListener2;
+import org.eclipse.ui.IWorkbenchPartReference;
+
+public class WorkspaceListener implements IPartListener2 {
+  @Override
+  public void partActivated(IWorkbenchPartReference partReference) {
+    var state = EditorState.from(partReference);
+    if (state != null) {
+      withAgent(
+          agent -> {
+            agent.focusChanged(state);
+          });
+    }
+  }
+
+  @Override
+  public void partOpened(IWorkbenchPartReference partReference) {
+    var state = EditorState.from(partReference);
+    if (state != null) {
+      withAgent(
+          agent -> {
+            agent.fileOpened(state);
+          });
+
+      setupSelectionListener(state);
+      setupContentListener(state);
+    }
+  }
+
+  public static void setupSelectionListener(EditorState state) {
+    state
+        .editor
+        .getSelectionProvider()
+        .addSelectionChangedListener(
+            event -> {
+              // We are sure it is a ITextEditor so it *should* use ITextSelection
+              var selection = ((ITextSelection) event.getSelection());
+              var document = state.getDocument();
+              var range = new Range();
+              range.start = positionFor(selection.getOffset(), document);
+              range.end = positionFor(selection.getOffset() + selection.getLength(), document);
+
+              withAgent(
+                  agent -> {
+                    agent.selectionChanged(state, range);
+                  });
+            });
+  }
+
+  public static void setupContentListener(EditorState state) {
+    state
+        .editor
+        .getDocumentProvider()
+        .getDocument(state.editor.getEditorInput())
+        .addDocumentListener(
+            new IDocumentListener() {
+              @Override
+              public void documentAboutToBeChanged(DocumentEvent documentEvent) {}
+
+              @Override
+              public void documentChanged(DocumentEvent documentEvent) {
+                withAgent(
+                    agent -> {
+                      agent.fileChanged(state);
+                    });
+              }
+            });
+  }
+
+  private static Position positionFor(int offset, IDocument document) {
+    try {
+      var line = document.getLineOfOffset(offset);
+      var lineOffset = document.getLineOffset(line);
+      var character = offset - lineOffset;
+      var position = new Position();
+      position.line = line;
+      position.character = character;
+      return position;
+    } catch (BadLocationException e) {
+      throw new WrappedRuntimeException(e);
+    }
+  }
+}


### PR DESCRIPTION
This PR implements the first iteration towards giving Cody codebase context in Eclipse:

- `textDocument/didOpen`
- `textDocument/didFocus`
- `textDocument/didChange`

There are a few remaining cases:

- `textDocument/didClose`
- `textDocument/didOpen` on agent restart
- `textDocument/did{Open,Change}` before agent starts


## Test plan

* Open a file
* Confirm the chat window auto-selects the file
* Submit question about the file
* Confirm answer has access to file
* Repeat for selection
* 
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
