### PR TITLE
Bundle node.js with plugin JAR file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .metals/
 *.jar
 .vscode/
+plugins/cody-chat/resources/node-binaries/
 plugins/cody-chat/resources/cody-agent/
 plugins/cody-chat/resources/cody-webviews/
 build.scala

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 all:
 	./scripts/build-agent.sh
 	./scripts/build-webview.sh
+	./scripts/download-node.sh
 bindings:
 	./scripts/build-java-bindings.sh
 format:

--- a/plugins/cody-chat/src/com/sourcegraph/cody/CodyAgent.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/CodyAgent.java
@@ -5,7 +5,6 @@ import com.sourcegraph.cody.protocol_generated.*;
 import com.sourcegraph.cody.workspace.EditorState;
 import com.sourcegraph.cody.workspace.WorkspaceListener;
 import dev.dirs.ProjectDirectories;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;

--- a/releng/cody-feature/run_with_java.launch
+++ b/releng/cody-feature/run_with_java.launch
@@ -27,7 +27,7 @@
     <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
     <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog"/>
     <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
-    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true -Dcody-agent.trace-path=${workspace_loc}/trace.json -Dcody.nodejs-executable=&quot;C:\Program Files\nodejs\node.exe&quot;"/>
+    <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Dorg.eclipse.swt.graphics.Resource.reportNonDisposed=true -Dcody-agent.trace-path=${workspace_loc}/trace.json"/>
     <stringAttribute key="pde.version" value="3.3"/>
     <stringAttribute key="product" value="org.eclipse.epp.package.committers.product"/>
     <setAttribute key="selected_features">

--- a/scripts/download-node.sh
+++ b/scripts/download-node.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -eux
+
+NODE_BINARY_URL="https://github.com/sourcegraph/node-binaries/raw/main/v20.12.2/node-win-x64.exe"
+
+# We only support Windows at this time
+mkdir -p plugins/cody-chat/resources/node-binaries
+curl -Lo plugins/cody-chat/resources/node-binaries/node-win-x64.exe "$NODE_BINARY_URL"


### PR DESCRIPTION
Previously, the plugin only worked in scenarios where the user either
explicitly configured a VM option pointing to the file path of a Node.js
binary, or if the Eclipse installation came included with Node.js via a
`.node` directory that doesn't exist install Eclipse installations.

This issue solves the problem by embedding a Node.js binary for Windows
x64 in the resources of the plugin. The downside of this fix is that the
plugin size is very large on every update even if the Node.js binary is
unchanged. If this is problematic, then we can consider splitting the
Node.js binary into a separate plugin that updates less frequently.

Fixes CODY-2864

## Test plan
Manually tested the plugin locally and it loads correctly from a Node.js binary in the path
```
C:\Users\olafu\AppData\Roaming\Sourcegraph\CodyEclipse\data\node-win-x64.exe
```


<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
