### PR TITLE
Use "jetbrains" client name instead of "eclipse"

### DIFF
--- a/plugins/cody-chat/src/com/sourcegraph/cody/CodyAgent.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/CodyAgent.java
@@ -279,7 +279,13 @@ public class CodyAgent implements IDisposable {
   private static void initialize(CodyAgentServer server, Path workspaceRoot)
       throws InterruptedException, ExecutionException, TimeoutException {
     ClientInfo clientInfo = new ClientInfo();
-    clientInfo.name = "cody-eclipse";
+    // See
+    // https://sourcegraph.com/github.com/sourcegraph/cody/-/blob/agent/src/cli/codyCliClientName.ts
+    // for a detailed explanation why we use the name "jetbrains" instead of "eclipse". The short
+    // explanation is that
+    // we need to wait for enterprise customers to upgrade to a new version that includes the fix
+    // from this PR here https://github.com/sourcegraph/sourcegraph/pull/63855.
+    clientInfo.name = "jetbrains";
     clientInfo.version = "0.2.1";
     clientInfo.workspaceRootUri = workspaceRoot.toUri().toString();
     ClientCapabilities capabilities = new ClientCapabilities();


### PR DESCRIPTION
Previously, we send an appropriate Cody agent client name "eclipse". This was problematic because it meant that the plugin didn't work with Enterprise server instances that have enabled context filters due to a check against old versions of clients that may not support context filters. The server checks have been fixed in https://github.com/sourcegraph/sourcegraph/pull/63855 but we need to wait a few months before being able to send "Eclipse" as a client name when Enterprise users have completed upgrading to a newer Sourcegraph version.

The big downside with this solution is that it means all the telemetry in the plugin indicates that events are coming from JetBrains. We can fix this problem by extending the Cody agent server protocol to accept a dedicated setting to override only the HTTP client name for LLM completion requests. This work is tracked in the issue CODY-2978.


## Test plan

n/a
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
