### PR TITLE
Bump up client version

### DIFF
--- a/plugins/cody-chat/src/com/sourcegraph/cody/CodyAgent.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/CodyAgent.java
@@ -286,7 +286,7 @@ public class CodyAgent implements IDisposable {
     // we need to wait for enterprise customers to upgrade to a new version that includes the fix
     // from this PR here https://github.com/sourcegraph/sourcegraph/pull/63855.
     clientInfo.name = "jetbrains";
-    clientInfo.version = "0.2.1";
+    clientInfo.version = "5.5.20-eclipse"; // Needs to be greater than 5.5.8
     clientInfo.workspaceRootUri = workspaceRoot.toUri().toString();
     ClientCapabilities capabilities = new ClientCapabilities();
     capabilities.chat = ClientCapabilities.ChatEnum.Streaming;


### PR DESCRIPTION
We go from 0.2.1 to 5.5.20-eclipse because we need to use a version higher than 5.5.8 to bypass the version filters of the remote server.


## Test plan

Manually tested the plugin locally against S2 and it worked.
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
