### PR TITLE
added/chat: persistent state

### DIFF
--- a/plugins/cody-chat/src/com/sourcegraph/cody/chat/agent/StartAgentJob.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/chat/agent/StartAgentJob.java
@@ -128,6 +128,7 @@ public class StartAgentJob extends Job {
     capabilities.chat = ClientCapabilities.ChatEnum.Streaming;
     // Enable string-encoding for webview messages.
     capabilities.webviewMessages = ClientCapabilities.WebviewMessagesEnum.String_encoded;
+    capabilities.globalState = ClientCapabilities.GlobalStateEnum.Server_managed;
     clientInfo.capabilities = capabilities;
 
     clientInfo.extensionConfiguration = manager.config; // TODO is that needed?

--- a/plugins/cody-chat/src/com/sourcegraph/cody/chat/agent/StartAgentJob.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/chat/agent/StartAgentJob.java
@@ -128,6 +128,7 @@ public class StartAgentJob extends Job {
     capabilities.chat = ClientCapabilities.ChatEnum.Streaming;
     // Enable string-encoding for webview messages.
     capabilities.webviewMessages = ClientCapabilities.WebviewMessagesEnum.String_encoded;
+    capabilities.webview = ClientCapabilities.WebviewEnum.Agentic;
     capabilities.globalState = ClientCapabilities.GlobalStateEnum.Server_managed;
     clientInfo.capabilities = capabilities;
 

--- a/plugins/cody-chat/src/com/sourcegraph/cody/chat/agent/StartAgentJob.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/chat/agent/StartAgentJob.java
@@ -121,7 +121,7 @@ public class StartAgentJob extends Job {
     // explanation is that
     // we need to wait for enterprise customers to upgrade to a new version that includes the fix
     // from this PR here https://github.com/sourcegraph/sourcegraph/pull/63855.
-    clientInfo.name = "jetbrains";
+    clientInfo.name = "eclipse";
     clientInfo.version = "5.5.21-eclipse"; // Needs to be greater than 5.5.8
     clientInfo.workspaceRootUri = workspaceRoot.toUri().toString();
     ClientCapabilities capabilities = new ClientCapabilities();

--- a/plugins/cody-chat/src/com/sourcegraph/cody/protocol_generated/Chat_Sidebar_NewResult.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/protocol_generated/Chat_Sidebar_NewResult.java
@@ -1,0 +1,6 @@
+package com.sourcegraph.cody.protocol_generated;
+
+public final class Chat_Sidebar_NewResult {
+  public String panelId;
+  public String chatId;
+}

--- a/plugins/cody-chat/src/com/sourcegraph/cody/protocol_generated/ClientCapabilities.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/protocol_generated/ClientCapabilities.java
@@ -14,6 +14,7 @@ public final class ClientCapabilities {
   public IgnoreEnum ignore; // Oneof: none, enabled
   public CodeActionsEnum codeActions; // Oneof: none, enabled
   public WebviewMessagesEnum webviewMessages; // Oneof: object-encoded, string-encoded
+  public GlobalStateEnum globalState; // Oneof: stateless, server-managed, client-managed
   public WebviewEnum webview; // Oneof: agentic, native
   public WebviewNativeConfigParams webviewNativeConfig;
 
@@ -104,6 +105,15 @@ public final class ClientCapabilities {
     Object_encoded,
     @com.google.gson.annotations.SerializedName("string-encoded")
     String_encoded,
+  }
+
+  public enum GlobalStateEnum {
+    @com.google.gson.annotations.SerializedName("stateless")
+    Stateless,
+    @com.google.gson.annotations.SerializedName("server-managed")
+    Server_managed,
+    @com.google.gson.annotations.SerializedName("client-managed")
+    Client_managed,
   }
 
   public enum WebviewEnum {

--- a/plugins/cody-chat/src/com/sourcegraph/cody/protocol_generated/ClientInfo.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/protocol_generated/ClientInfo.java
@@ -5,6 +5,7 @@ public final class ClientInfo {
   public String version;
   public String ideVersion;
   public String workspaceRootUri;
+  public String globalStateDir;
   public String workspaceRootPath;
   public ExtensionConfiguration extensionConfiguration;
   public ClientCapabilities capabilities;

--- a/plugins/cody-chat/src/com/sourcegraph/cody/protocol_generated/CodyAgentClient.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/protocol_generated/CodyAgentClient.java
@@ -87,4 +87,7 @@ public interface CodyAgentClient {
 
   @JsonNotification("webview/setHtml")
   void webview_setHtml(Webview_SetHtmlParams params);
+
+  @JsonNotification("window/didChangeContext")
+  void window_didChangeContext(Window_DidChangeContextParams params);
 }

--- a/plugins/cody-chat/src/com/sourcegraph/cody/protocol_generated/CodyAgentServer.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/protocol_generated/CodyAgentServer.java
@@ -21,6 +21,9 @@ public interface CodyAgentServer {
   @JsonRequest("chat/web/new")
   CompletableFuture<Chat_Web_NewResult> chat_web_new(Void params);
 
+  @JsonRequest("chat/sidebar/new")
+  CompletableFuture<Chat_Sidebar_NewResult> chat_sidebar_new(Void params);
+
   @JsonRequest("chat/delete")
   CompletableFuture<java.util.List<ChatExportResult>> chat_delete(Chat_DeleteParams params);
 

--- a/plugins/cody-chat/src/com/sourcegraph/cody/protocol_generated/Constants.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/protocol_generated/Constants.java
@@ -21,6 +21,7 @@ public final class Constants {
   public static final String byok = "byok";
   public static final String chat = "chat";
   public static final String class_ = "class";
+  public static final String client_managed = "client-managed";
   public static final String complete = "complete";
   public static final String create_file = "create-file";
   public static final String default_ = "default";
@@ -69,7 +70,9 @@ public final class Constants {
   public static final String request = "request";
   public static final String search = "search";
   public static final String selection = "selection";
+  public static final String server_managed = "server-managed";
   public static final String speed = "speed";
+  public static final String stateless = "stateless";
   public static final String streaming = "streaming";
   public static final String string_encoded = "string-encoded";
   public static final String suggestion = "suggestion";

--- a/plugins/cody-chat/src/com/sourcegraph/cody/protocol_generated/Window_DidChangeContextParams.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/protocol_generated/Window_DidChangeContextParams.java
@@ -1,0 +1,6 @@
+package com.sourcegraph.cody.protocol_generated;
+
+public final class Window_DidChangeContextParams {
+  public String key;
+  public String value;
+}


### PR DESCRIPTION
Adds persistent state access to the agent. Used to support chat history.

Because I updated the ClientInfo struct, I re-ran the Java generation. However, that caused a bunch of compilation errors because the `WebviewMessage` wasn't generated, and nor were a bunch of its dependencies. I had to manually restore that file and some of its dependencies to get it to compile. Am I missing a step here? 

I'll call out the places where a real change was made.

## Test plan
Manually tested the plugin persisted chat.
