### PR TITLE
fixed/assets: copy assets to shared directory

### DIFF
--- a/plugins/cody-chat/src/com/sourcegraph/cody/chat/agent/StartAgentJob.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/chat/agent/StartAgentJob.java
@@ -154,7 +154,6 @@ public class StartAgentJob extends Job {
         ProjectDirectories.from("com.sourcegraph", "Sourcegraph", "CodyEclipse");
     return Paths.get(dirs.dataDir);
   }
-
   private void copyResourcePath(String path, Path target) throws IOException {
     try (InputStream in = getClass().getResourceAsStream(path)) {
       if (in == null) {
@@ -164,6 +163,7 @@ public class StartAgentJob extends Job {
                     + "run `./scripts/build-agent.sh` and try again.",
                 path));
       }
+      Files.createDirectories(target.getParent());
       Files.copy(in, target, StandardCopyOption.REPLACE_EXISTING);
     }
   }

--- a/scripts/build-agent.sh
+++ b/scripts/build-agent.sh
@@ -4,14 +4,14 @@ set -eux
 # sibling directory.
 pushd ../cody
 pnpm dlx pnpm@8.6.7 install
-pnpm dlx pnpm@8.6.7 -C agent build:agent
+pnpm dlx pnpm@8.6.7 -C agent build
 popd
 mkdir -p plugins/cody-chat/resources/cody-agent
 cp ../cody/agent/dist/index.js plugins/cody-chat/resources/cody-agent
-cp ../cody/agent/dist/*.wasm   plugins/cody-chat/resources/cody-agent
-cp ../cody/agent/dist/win-ca-roots.exe   plugins/cody-chat/resources/cody-agent
-ASSETS_FILE=plugins/cody-chat/resources/cody-agent/assets.txt
-rm -f $ASSETS_FILE
-for f in plugins/cody-chat/resources/cody-agent/*; do
-  echo $(basename $f) >> $ASSETS_FILE
-done
+cp ../cody/agent/dist/*.wasm plugins/cody-chat/resources/cody-agent
+cp ../cody/agent/dist/win-ca-roots.exe plugins/cody-chat/resources/cody-agent
+cp -r ../cody/agent/dist/webview plugins/cody-chat/resources/cody-agent
+pushd plugins/cody-chat/resources/cody-agent
+rm -f assets.txt
+find . -type f >assets.txt
+popd


### PR DESCRIPTION
A change on the latest cody branch is causing this to fail because the webviews aren't present in `~/AppData/Roaming/Cody-nodejs/webviews`. This error manifests with an earlier error `copyExtensionRelativeResources: Failed to find C:\Users\James\AppData\Roaming\Sourcegraph\CodyEclipse\data\webviews, skipping copy`. I can't find any instance of `copyExtensionRelativeResources` in either repo though.

This is a nasty hack that adds the webview files to the `assets.txt` so they get copied over to the CodyEclipse dir, and then they are copied over to the Cody-nodejs dir. It seems like in the past we were just serving the files out of the resources, but I wasn't able to figure out why that isn't working anymore, so I resorted to this nastiness. If someone else knows why this has changed, I'd be happy to close this.

## Test plan
Ran manually