### PR TITLE
CODY-3559: Remove RPC communication from log view

### DIFF
--- a/plugins/cody-chat/src/com/sourcegraph/cody/CodyPaths.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/CodyPaths.java
@@ -1,0 +1,41 @@
+package com.sourcegraph.cody;
+
+import dev.dirs.ProjectDirectories;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class CodyPaths {
+
+  public static String serverTracePath() {
+    var override = System.getProperty("cody.debug-trace-path");
+    if (override != null) {
+      return override;
+    }
+    return Paths.get(projectDirectories().dataLocalDir).resolve("server-debug.json").toString();
+  }
+
+  public static String clientTracePath() {
+    var override = System.getProperty("cody-agent.trace-path");
+    if (override != null) {
+      return override;
+    }
+    return Paths.get(projectDirectories().dataLocalDir).resolve("client-debug.json").toString();
+  }
+
+  public static ProjectDirectories projectDirectories() {
+    return ProjectDirectories.from("com.sourcegraph", "Sourcegraph", "CodyEclipse");
+  }
+
+  public static Path dataDir() {
+    return Paths.get(projectDirectories().dataDir);
+  }
+
+  public static Path agentScript(CodyResources resources) throws IOException {
+    String userProvidedAgentScript = System.getProperty("cody.agent-script-path");
+    if (userProvidedAgentScript != null) {
+      return Paths.get(userProvidedAgentScript);
+    }
+    return resources.getAgentEntry();
+  }
+}

--- a/plugins/cody-chat/src/com/sourcegraph/cody/chat/ChatView.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/chat/ChatView.java
@@ -80,15 +80,7 @@ public class ChatView extends ViewPart {
   }
 
   private void doPostMessage(Browser browser, String message) {
-    display.asyncExec(
-        () -> {
-          String stringifiedMessage = gson.toJson(message);
-          // Only log non-transcript messages
-          if (!stringifiedMessage.contains("\\\"type\\\":\\\"transcript\\\"")) {
-            log.sent(stringifiedMessage);
-          }
-          browser.execute("eclipse_postMessage(" + stringifiedMessage + ");");
-        });
+    display.asyncExec(() -> browser.execute("eclipse_postMessage(" + gson.toJson(message) + ");"));
   }
 
   private void connectWebviewToBrowser(Browser browser) {
@@ -165,7 +157,6 @@ public class ChatView extends ViewPart {
     new BrowserFunction(browser, "eclipse_interceptMessage") {
       @Override
       public Object function(Object[] arguments) {
-        log.received(arguments[0].toString() + " (Intercepted)");
         if (chatId.isEmpty()) {
           log.warn("No chat ID");
           return null;
@@ -186,7 +177,6 @@ public class ChatView extends ViewPart {
     new BrowserFunction(browser, "eclipse_receiveMessage") {
       @Override
       public Object function(Object[] arguments) {
-        log.received(arguments[0].toString());
         if (chatId.isEmpty()) {
           log.warn("No chat ID");
           return null;

--- a/plugins/cody-chat/src/com/sourcegraph/cody/logging/CodyLogger.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/logging/CodyLogger.java
@@ -1,5 +1,6 @@
 package com.sourcegraph.cody.logging;
 
+import com.sourcegraph.cody.CodyPaths;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.time.LocalDateTime;
@@ -60,14 +61,6 @@ public class CodyLogger {
     INSTANCE.log(new LogMessage(LogMessage.Kind.INFO, message, LocalDateTime.now()));
   }
 
-  public void received(String message) {
-    INSTANCE.log(new LogMessage(LogMessage.Kind.RECEIVED, message, LocalDateTime.now()));
-  }
-
-  public void sent(String message) {
-    INSTANCE.log(new LogMessage(LogMessage.Kind.SENT, message, LocalDateTime.now()));
-  }
-
   static class Internal {
 
     // plugin version, os, architecture and similar info
@@ -101,6 +94,13 @@ public class CodyLogger {
               System.getProperty("os.version"),
               System.getProperty("os.arch"));
       environment.add(new LogMessage(LogMessage.Kind.INFO, system, LocalDateTime.now()));
+
+      var traceFiles =
+          "Cody agent client trace file: "
+              + CodyPaths.clientTracePath()
+              + ", server trace path:"
+              + CodyPaths.serverTracePath();
+      environment.add(new LogMessage(LogMessage.Kind.INFO, traceFiles, LocalDateTime.now()));
 
       addConnectedInstanceMsg();
     }

--- a/plugins/cody-chat/src/com/sourcegraph/cody/logging/LogContentProvider.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/logging/LogContentProvider.java
@@ -65,10 +65,6 @@ public class LogContentProvider extends LabelProvider
         return icons.warn;
       case INFO:
         return icons.info;
-      case RECEIVED:
-        return icons.received;
-      case SENT:
-        return icons.sent;
       default:
         return null;
     }

--- a/plugins/cody-chat/src/com/sourcegraph/cody/logging/LogMessage.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/logging/LogMessage.java
@@ -8,8 +8,6 @@ public class LogMessage {
     ERROR,
     WARNING,
     INFO,
-    RECEIVED,
-    SENT
   }
 
   public final Kind kind;

--- a/plugins/cody-chat/src/com/sourcegraph/cody/logging/LogView.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/logging/LogView.java
@@ -108,8 +108,6 @@ public class LogView extends ViewPart {
       Button errorCheckBox = createCheckbox("Errors", icons.error, true);
       Button warnCheckBox = createCheckbox("Warnings", icons.warn, true);
       Button infoCheckBox = createCheckbox("Info", icons.info, true);
-      Button receivedCheckBox = createCheckbox("Received messages", icons.received, false);
-      Button sentCheckBox = createCheckbox("Sent messages", icons.sent, false);
 
       filter =
           new ViewerFilter() {
@@ -129,10 +127,6 @@ public class LogView extends ViewPart {
                   return warnCheckBox.getSelection();
                 case INFO:
                   return infoCheckBox.getSelection();
-                case RECEIVED:
-                  return receivedCheckBox.getSelection();
-                case SENT:
-                  return sentCheckBox.getSelection();
               }
               return true;
             }


### PR DESCRIPTION
Removes logs of RPC traces from Log View and sets default trace files.

## Test plan
Ran on MacOS and saw that log view contains only debug messages and paths for client and server logs.
![image](https://github.com/user-attachments/assets/b3a1f201-8599-42a8-bb3d-7831a3b976fc)
