### PR TITLE
Add working reload command

### DIFF
--- a/plugins/cody-chat/plugin.xml
+++ b/plugins/cody-chat/plugin.xml
@@ -52,5 +52,13 @@
             message="com.sourcegraph.cody.webview_protocol.WebviewMessage$InsertWebviewMessage">
       </handler>
    </extension>
+   <extension
+         point="org.eclipse.ui.commands">
+      <command
+            defaultHandler="com.sourcegraph.cody.chat.agent.ReloadHandler"
+            id="com.sourcegraph.cody.chat.agent.reload"
+            name="Restart Cody Agent">
+      </command>
+   </extension>
 
 </plugin>

--- a/plugins/cody-chat/src/com/sourcegraph/cody/chat/ChatView.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/chat/ChatView.java
@@ -23,8 +23,6 @@ import org.eclipse.swt.browser.Browser;
 import org.eclipse.swt.browser.BrowserFunction;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
-import org.eclipse.ui.ISharedImages;
-import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.part.ViewPart;
 
 @SuppressWarnings("unused")
@@ -61,7 +59,6 @@ public class ChatView extends ViewPart {
   @Override
   public void createPartControl(Composite parent) {
     try {
-      addRestartCodyAction();
       addWebview(parent);
     } catch (Exception e) {
       log.error("Cannot create chat view", e);
@@ -217,35 +214,14 @@ public class ChatView extends ViewPart {
     getViewSite().getActionBars().getToolBarManager().add(action);
   }
 
-  private void addRestartCodyAction() {
-    // This is disabled by default because it doesn't work correctly. When you
-    // restart, the
-    // webview gets stuck in a loading state.
-    //    if (!"true".equals(System.getProperty("cody-agent.restart-button", "false"))) {
-    //      return;
-    //    }
-    var action =
-        new Action() {
-          @Override
-          public void run() {
-            manager.withAgent(CodyAgent::dispose);
-            manager.withAgent(
-                agent -> {
-                  log.info("Agent restarted successfully");
-                  Display.getDefault().asyncExec(() -> browserField.refresh());
-                  newWebview(browserField, agent);
-                });
-          }
-        };
-
-    action.setText("Restart Cody");
-    action.setToolTipText("Restart Cody Agent");
-    action.setImageDescriptor(
-        PlatformUI.getWorkbench()
-            .getSharedImages()
-            .getImageDescriptor(ISharedImages.IMG_ELCL_SYNCED));
-
-    addActionToToolbar(action);
+  public void reload() {
+    manager.withAgent(CodyAgent::dispose);
+    manager.withAgent(
+        agent -> {
+          log.info("Agent restarted successfully");
+          Display.getDefault().asyncExec(() -> browserField.refresh());
+          newWebview(browserField, agent);
+        });
   }
 
   @Override

--- a/plugins/cody-chat/src/com/sourcegraph/cody/chat/ChatView.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/chat/ChatView.java
@@ -127,7 +127,7 @@ public class ChatView extends ViewPart {
     // We have the chat ID, let's update the browser URL.
     display.asyncExec(
         () -> {
-          createCallbacks(browser, agent);
+          createCallbacks(browser);
           var url = String.format("http://localhost:%d", agent.webviewPort);
           browser.setUrl(url);
           browser.getParent().layout();
@@ -145,7 +145,7 @@ public class ChatView extends ViewPart {
     }
   }
 
-  private void createCallbacks(Browser browser, CodyAgent agent) {
+  private void createCallbacks(Browser browser) {
     if (browser == null) {
       return;
     }
@@ -198,7 +198,7 @@ public class ChatView extends ViewPart {
                   new Webview_ReceiveMessageStringEncodedParams();
               params.id = chatId;
               params.messageStringEncoded = messageJson;
-              agent.server.webview_receiveMessageStringEncoded(params);
+              manager.withAgent(agent -> agent.server.webview_receiveMessageStringEncoded(params));
             });
         return null;
       }
@@ -218,11 +218,12 @@ public class ChatView extends ViewPart {
   }
 
   private void addRestartCodyAction() {
-    // This is disabled by default because it doesn't work correctly. When you restart, the
+    // This is disabled by default because it doesn't work correctly. When you
+    // restart, the
     // webview gets stuck in a loading state.
-    if (!"true".equals(System.getProperty("cody-agent.restart-button", "false"))) {
-      return;
-    }
+    //    if (!"true".equals(System.getProperty("cody-agent.restart-button", "false"))) {
+    //      return;
+    //    }
     var action =
         new Action() {
           @Override
@@ -231,7 +232,7 @@ public class ChatView extends ViewPart {
             manager.withAgent(
                 agent -> {
                   log.info("Agent restarted successfully");
-                  browserField.refresh();
+                  Display.getDefault().asyncExec(() -> browserField.refresh());
                   newWebview(browserField, agent);
                 });
           }

--- a/plugins/cody-chat/src/com/sourcegraph/cody/chat/agent/CodyAgent.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/chat/agent/CodyAgent.java
@@ -57,8 +57,8 @@ public class CodyAgent implements Disposable {
       case IGNORE:
         break;
       case LOG:
-        dispose();
         log.error("Error running agent action", failure);
+        dispose();
         break;
       case THROW:
         dispose();
@@ -115,8 +115,8 @@ public class CodyAgent implements Disposable {
   }
 
   public void dispose() {
-    workbenchListener.dispose();
     try {
+      workbenchListener.dispose();
       server.shutdown(null).get(1, TimeUnit.SECONDS);
       server.exit(null);
       listening.cancel(true);

--- a/plugins/cody-chat/src/com/sourcegraph/cody/chat/agent/ReloadHandler.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/chat/agent/ReloadHandler.java
@@ -1,0 +1,21 @@
+package com.sourcegraph.cody.chat.agent;
+
+import com.sourcegraph.cody.chat.ChatView;
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.ui.PlatformUI;
+
+public class ReloadHandler extends AbstractHandler {
+
+  @Override
+  public Object execute(ExecutionEvent event) throws ExecutionException {
+    var view =
+        PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage().findView(ChatView.ID);
+
+    if (view instanceof ChatView) {
+      ((ChatView) view).reload();
+    }
+    return null;
+  }
+}

--- a/plugins/cody-chat/src/com/sourcegraph/cody/workspace/CodyContentListener.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/workspace/CodyContentListener.java
@@ -3,6 +3,7 @@ package com.sourcegraph.cody.workspace;
 import com.sourcegraph.cody.chat.agent.CodyAgent;
 import org.eclipse.jface.text.DocumentEvent;
 import org.eclipse.jface.text.IDocumentListener;
+import org.eclipse.swt.widgets.Display;
 
 public class CodyContentListener implements CodyListener, IDocumentListener {
   private final CodyAgent agent;
@@ -21,7 +22,7 @@ public class CodyContentListener implements CodyListener, IDocumentListener {
 
   @Override
   public void dispose() {
-    editorState.getDocument().removeDocumentListener(this);
+    Display.getDefault().execute(() -> editorState.getDocument().removeDocumentListener(this));
   }
 
   @Override

--- a/plugins/cody-chat/src/com/sourcegraph/cody/workspace/CodySelectionListener.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/workspace/CodySelectionListener.java
@@ -4,6 +4,7 @@ import com.sourcegraph.cody.chat.agent.CodyAgent;
 import org.eclipse.jface.text.ITextSelection;
 import org.eclipse.jface.viewers.ISelectionChangedListener;
 import org.eclipse.jface.viewers.SelectionChangedEvent;
+import org.eclipse.swt.widgets.Display;
 
 public class CodySelectionListener implements CodyListener, ISelectionChangedListener {
   private final CodyAgent agent;
@@ -33,6 +34,6 @@ public class CodySelectionListener implements CodyListener, ISelectionChangedLis
 
   @Override
   public void dispose() {
-    editorState.editor.getSelectionProvider().removeSelectionChangedListener(this);
+    Display.getDefault().execute(() -> editorState.editor.getSelectionProvider().removeSelectionChangedListener(this));
   }
 }

--- a/plugins/cody-chat/src/com/sourcegraph/cody/workspace/CodySelectionListener.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/workspace/CodySelectionListener.java
@@ -34,6 +34,8 @@ public class CodySelectionListener implements CodyListener, ISelectionChangedLis
 
   @Override
   public void dispose() {
-    Display.getDefault().execute(() -> editorState.editor.getSelectionProvider().removeSelectionChangedListener(this));
+    Display.getDefault()
+        .execute(
+            () -> editorState.editor.getSelectionProvider().removeSelectionChangedListener(this));
   }
 }

--- a/plugins/cody-chat/src/com/sourcegraph/cody/workspace/WorkbenchListener.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/workspace/WorkbenchListener.java
@@ -1,11 +1,9 @@
 package com.sourcegraph.cody.workspace;
 
 import com.sourcegraph.cody.chat.agent.CodyAgent;
-
 import java.util.Collections;
 import java.util.Set;
 import java.util.WeakHashMap;
-
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IPartListener2;
 import org.eclipse.ui.IWorkbenchPartReference;

--- a/plugins/cody-chat/src/com/sourcegraph/cody/workspace/WorkbenchListener.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/workspace/WorkbenchListener.java
@@ -1,9 +1,11 @@
 package com.sourcegraph.cody.workspace;
 
 import com.sourcegraph.cody.chat.agent.CodyAgent;
+
 import java.util.Collections;
 import java.util.Set;
 import java.util.WeakHashMap;
+
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IPartListener2;
 import org.eclipse.ui.IWorkbenchPartReference;
@@ -89,9 +91,16 @@ public class WorkbenchListener implements IPartListener2, CodyListener {
 
   @Override
   public void dispose() {
-    for (var child : children) {
-      child.dispose();
-    }
-    PlatformUI.getWorkbench().getActiveWorkbenchWindow().getPartService().removePartListener(this);
+    Display.getDefault()
+        .execute(
+            () -> {
+              for (var child : children) {
+                child.dispose();
+              }
+              PlatformUI.getWorkbench()
+                  .getActiveWorkbenchWindow()
+                  .getPartService()
+                  .removePartListener(this);
+            });
   }
 }


### PR DESCRIPTION
This PR fixes FOUR subtle bugs that worked in perfect coordination to leave the UI in a completely broken state silently after running the restart agent command. Also, now the command is accessible only via Eclipse's command palette.

## Test plan
- open chat view
- ask some question
- press `Cmd + 3`
- start typing `Restart Cody Agent`
- once the command shows up, press Enter

After a few seconds, Chat View should refresh and still work correctly.

## Future improvement
There should be some indication that Cody is reloading. We can show the spinner or fade the review.
