### PR TITLE
Add better project info

### DIFF
--- a/plugins/cody-chat/src/com/sourcegraph/cody/workspace/EditorState.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/workspace/EditorState.java
@@ -7,6 +7,7 @@ import com.sourcegraph.cody.protocol_generated.Range;
 import java.net.URI;
 import java.nio.file.Paths;
 import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IResource;
 import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
@@ -17,6 +18,7 @@ import org.eclipse.ui.texteditor.ITextEditor;
 public final class EditorState {
   public final IFile file;
   public final String uri;
+  public final String projectUri;
   public final ITextEditor editor;
   @Nullable private IDocument document = null;
 
@@ -25,17 +27,8 @@ public final class EditorState {
   private EditorState(IFile file, ITextEditor editor) {
     this.file = file;
     this.uri = EditorState.getUri(file);
+    this.projectUri = EditorState.getUri(file.getProject());
     this.editor = editor;
-  }
-
-  private static String getUri(IFile file) {
-    URI uri = file.getLocationURI();
-    if (uri.getScheme().equals("file")) {
-      // Fixes CODY-3513
-      return Paths.get(uri).toUri().toString();
-    }
-
-    return uri.toString();
   }
 
   public String readContents() {
@@ -87,5 +80,15 @@ public final class EditorState {
     }
     var file1 = ((FileEditorInput) input).getFile();
     return new EditorState(file1, editor1);
+  }
+
+  static String getUri(IResource file) {
+    URI uri = file.getLocationURI();
+    if (uri.getScheme().equals("file")) {
+      // Fixes CODY-3513
+      return Paths.get(uri).toUri().toString();
+    }
+
+    return uri.toString();
   }
 }

--- a/plugins/cody-chat/src/com/sourcegraph/cody/workspace/ProjectCreationListener.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/workspace/ProjectCreationListener.java
@@ -1,0 +1,32 @@
+package com.sourcegraph.cody.workspace;
+
+import com.sourcegraph.cody.chat.agent.CodyAgent;
+import org.eclipse.core.resources.*;
+
+public class ProjectCreationListener implements CodyListener, IResourceChangeListener {
+  private final CodyAgent agent;
+
+  public ProjectCreationListener(CodyAgent agent) {
+    this.agent = agent;
+  }
+
+  @Override
+  public void install() {
+    ResourcesPlugin.getWorkspace()
+        .addResourceChangeListener(this, IResourceChangeEvent.POST_CHANGE);
+  }
+
+  @Override
+  public void dispose() {
+    ResourcesPlugin.getWorkspace().removeResourceChangeListener(this);
+  }
+
+  @Override
+  public void resourceChanged(IResourceChangeEvent event) {
+    for (var c : event.getDelta().getAffectedChildren()) {
+      if (c.getResource() instanceof IProject && c.getKind() == IResourceDelta.ADDED) {
+        agent.projectChanged(EditorState.getUri(c.getResource()));
+      }
+    }
+  }
+}

--- a/plugins/cody-chat/src/com/sourcegraph/cody/workspace/WorkbenchListener.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/workspace/WorkbenchListener.java
@@ -61,6 +61,9 @@ public class WorkbenchListener implements IPartListener2, CodyListener {
                   .getPartService()
                   .addPartListener(this);
             });
+    var projectCreationListener = new ProjectCreationListener(agent);
+    projectCreationListener.install();
+    children.add(projectCreationListener);
   }
 
   @Override
@@ -84,6 +87,14 @@ public class WorkbenchListener implements IPartListener2, CodyListener {
       selectionListener.install();
 
       agent.focusChanged(state);
+    }
+  }
+
+  @Override
+  public void partClosed(IWorkbenchPartReference partReference) {
+    var state = EditorState.from(partReference);
+    if (state != null) {
+      agent.fileClosed(state);
     }
   }
 


### PR DESCRIPTION
For now, we don't support multiple workspace roots. I added the ability to switch between different roots based on the file in the last active editor.  Moreover, if no editor is open, creating a new project should set it as a new root.

I don't like that after closing all the editors, we still see the last opened file as context info.  I tried to fix that with `textDocument_didClose`, but it doesn't work.

## Test plan

- create more than one project in the workspace
- open files from different projects in different editor tabs
- switch between editor tabs
- [ ] the project should be visible as Cody's workspace root
- close all the editor tabs
- create a new project
- [ ] newly created project should be a current Cody's workspace root