### PR TITLE
Distribute Node.js binary for Linux x64

### DIFF
--- a/plugins/cody-chat/src/com/sourcegraph/cody/CodyResources.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/CodyResources.java
@@ -138,6 +138,8 @@ public class CodyResources {
       return "node-win-x64.exe";
     } else if (Platform.OS.isMac() && Platform.getOSArch().equals(Platform.ARCH_AARCH64)) {
       return "node-macos-arm64";
+    } else if (Platform.OS.isLinux() && Platform.getOSArch().equals(Platform.ARCH_X86_64)) {
+      return "node-linux-x64";
     }
     return "";
   }

--- a/scripts/download-node.sh
+++ b/scripts/download-node.sh
@@ -3,8 +3,10 @@ set -eux
 
 NODE_WINDOWS_BINARY_URL="https://github.com/sourcegraph/node-binaries/raw/main/v20.12.2/node-win-x64.exe"
 NODE_MACOS_BINARY_URL="https://github.com/sourcegraph/node-binaries/raw/main/v20.12.2/node-macos-arm64"
+LINUX_BINARY_URL="https://github.com/sourcegraph/node-binaries/raw/main/v20.12.2/node-linux-x64"
 
 # We only support Windows at this time
 mkdir -p plugins/cody-chat/resources/node-binaries
 curl -Lo plugins/cody-chat/resources/node-binaries/node-win-x64.exe "$NODE_WINDOWS_BINARY_URL"
 curl -Lo plugins/cody-chat/resources/node-binaries/node-macos-arm64 "$NODE_MACOS_BINARY_URL"
+curl -Lo plugins/cody-chat/resources/node-binaries/node-linux-x64 "$LINUX_BINARY_URL"


### PR DESCRIPTION
Fixes CODY-3631

## Test plan
N/a
<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
