### PR TITLE
UI for code edits

### DIFF
--- a/plugins/cody-chat/plugin.xml
+++ b/plugins/cody-chat/plugin.xml
@@ -59,6 +59,11 @@
             id="com.sourcegraph.cody.chat.agent.reload"
             name="Restart Cody Agent">
       </command>
+      <command
+            defaultHandler="com.sourcegraph.cody.workspace.LensDebugHandler"
+            id="com.sourcegraph.cody.chat.agent.lens"
+            name="Test Edits">
+      </command>
    </extension>
 
 </plugin>

--- a/plugins/cody-chat/src/com/sourcegraph/cody/chat/agent/CodyAgent.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/chat/agent/CodyAgent.java
@@ -1,5 +1,6 @@
 package com.sourcegraph.cody.chat.agent;
 
+import com.sourcegraph.cody.edits.EditManager;
 import com.sourcegraph.cody.logging.CodyLogger;
 import com.sourcegraph.cody.protocol_generated.CodyAgentServer;
 import com.sourcegraph.cody.protocol_generated.ProtocolTextDocument;
@@ -17,6 +18,8 @@ public class CodyAgent implements Disposable {
   public final CodyAgentServer server;
   public final int webviewPort;
   public final CodyAgentClientImpl client;
+  public final EditManager editManager;
+
   private final Process process;
   private final CodyManager manager;
   private final WorkbenchListener workbenchListener;
@@ -37,6 +40,7 @@ public class CodyAgent implements Disposable {
     this.process = process;
     this.manager = manager;
     workbenchListener = new WorkbenchListener(this);
+    editManager = new EditManager();
   }
 
   public void runChecked(OnFailure onFailure, Consumer<CodyAgent> action) {

--- a/plugins/cody-chat/src/com/sourcegraph/cody/chat/agent/CodyManager.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/chat/agent/CodyManager.java
@@ -80,4 +80,11 @@ public class CodyManager {
           "Agent disposed before being started. This should never have happened.");
     }
   }
+
+  // TODO: remove the backdoor
+  public static CodyManager INSTANCE;
+
+  public CodyManager() {
+    INSTANCE = this;
+  }
 }

--- a/plugins/cody-chat/src/com/sourcegraph/cody/chat/agent/StartAgentJob.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/chat/agent/StartAgentJob.java
@@ -153,6 +153,8 @@ public class StartAgentJob extends Job {
     webviewConfig.injectStyle = CodyResources.loadInjectedCSS();
     capabilities.webviewNativeConfig = webviewConfig;
     capabilities.globalState = ClientCapabilities.GlobalStateEnum.Server_managed;
+    capabilities.editWorkspace = ClientCapabilities.EditWorkspaceEnum.Enabled;
+    capabilities.edit = ClientCapabilities.EditEnum.Enabled;
     clientInfo.capabilities = capabilities;
 
     var serverInfo = server.initialize(clientInfo).get(20, TimeUnit.SECONDS);

--- a/plugins/cody-chat/src/com/sourcegraph/cody/edits/EditManager.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/edits/EditManager.java
@@ -1,0 +1,36 @@
+package com.sourcegraph.cody.edits;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.widgets.Display;
+
+public class EditManager {
+  public final Image codyIcon =
+      new Image(Display.getDefault(), getClass().getResourceAsStream("/icons/sample.png"));
+
+  private final Map<String, FileEditManager> managers;
+
+  public EditManager() {
+    this.managers = new ConcurrentHashMap<>();
+  }
+
+  public FileEditManager get(String filePath) {
+    return managers.get(filePath);
+  }
+
+  public void register(String uri, FileEditManager manager) {
+    managers.put(uri, manager);
+  }
+
+  public void unregister(String uri) {
+    managers.remove(uri);
+  }
+
+  public void addEdit(String uri, FileEdit edit) {
+    FileEditManager manager = managers.get(uri);
+    if (manager != null) {
+      manager.addEdit(edit);
+    }
+  }
+}

--- a/plugins/cody-chat/src/com/sourcegraph/cody/edits/FileEdit.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/edits/FileEdit.java
@@ -1,0 +1,13 @@
+package com.sourcegraph.cody.edits;
+
+public class FileEdit {
+  public final int offset;
+  public final int length;
+  public final String text;
+
+  public FileEdit(int offset, int length, String text) {
+    this.offset = offset;
+    this.length = length;
+    this.text = text;
+  }
+}

--- a/plugins/cody-chat/src/com/sourcegraph/cody/edits/FileEditManager.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/edits/FileEditManager.java
@@ -1,0 +1,291 @@
+package com.sourcegraph.cody.edits;
+
+import com.sourcegraph.cody.WrappedRuntimeException;
+import com.sourcegraph.cody.workspace.CodyListener;
+import com.sourcegraph.cody.workspace.EditorState;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.ITextViewer;
+import org.eclipse.jface.text.Position;
+import org.eclipse.jface.text.codemining.AbstractCodeMining;
+import org.eclipse.jface.text.codemining.ICodeMining;
+import org.eclipse.jface.text.codemining.ICodeMiningProvider;
+import org.eclipse.jface.text.codemining.LineHeaderCodeMining;
+import org.eclipse.jface.text.source.ISourceViewer;
+import org.eclipse.jface.text.source.ISourceViewerExtension5;
+import org.eclipse.swt.custom.StyleRange;
+import org.eclipse.swt.custom.StyledText;
+import org.eclipse.swt.custom.StyledTextLineSpacingProvider;
+import org.eclipse.swt.events.MouseEvent;
+import org.eclipse.swt.events.VerifyListener;
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.graphics.GC;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.graphics.Point;
+import org.eclipse.swt.widgets.Display;
+
+public class FileEditManager
+    implements ICodeMiningProvider, StyledTextLineSpacingProvider, CodyListener {
+
+  private final EditorState state;
+  private final EditManager manager;
+  private final ISourceViewer viewer;
+  private final ISourceViewerExtension5 viewerExtension;
+
+  private final Set<FileEdit> edits;
+  private final Map<FileEdit, CompletableFuture<FileEditUi>> cache;
+  private final Map<Integer, Integer> lineSpacings;
+
+  private final Color backgroundRed;
+  private final Color backgroundGreen;
+
+  private final AtomicBoolean disposing = new AtomicBoolean(false);
+
+  public FileEditManager(EditorState state, EditManager manager) {
+    this.state = state;
+    this.manager = manager;
+
+    viewer = (ISourceViewer) state.editor.getAdapter(ITextViewer.class);
+    viewerExtension = (ISourceViewerExtension5) viewer;
+
+    edits = Collections.newSetFromMap(new ConcurrentHashMap<>());
+    cache = new ConcurrentHashMap<>();
+    lineSpacings = new ConcurrentHashMap<>();
+
+    backgroundRed = new Color(Display.getDefault(), 255, 220, 220);
+    backgroundGreen = new Color(Display.getDefault(), 220, 255, 220);
+  }
+
+  @Override
+  public CompletableFuture<List<? extends ICodeMining>> provideCodeMinings(
+      ITextViewer viewer, IProgressMonitor monitor) {
+    var futures =
+        edits.stream()
+            .map(f -> cache.computeIfAbsent(f, this::createUi))
+            .collect(Collectors.toList());
+    return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
+        .thenApply(
+            v ->
+                futures.stream()
+                    .map(CompletableFuture::join)
+                    .flatMap(f -> f.minings.stream())
+                    .collect(Collectors.toList()));
+  }
+
+  @Override
+  public Integer getLineSpacing(int lineIndex) {
+    return lineSpacings.getOrDefault(lineIndex, 0) * viewer.getTextWidget().getLineHeight();
+  }
+
+  @Override
+  public void install() {
+    viewerExtension.setCodeMiningProviders(new ICodeMiningProvider[] {this});
+    viewer.getTextWidget().setLineSpacingProvider(this);
+    manager.register(state.uri, this);
+
+    System.out.println(state.uri);
+  }
+
+  @Override
+  public void dispose() {
+    // This can be called either when agent is disposed, or the editor it is connected to is
+    // closed. In the first case this may trigger dispose more than once.
+    if (disposing.getAndSet(true)) {
+      return;
+    }
+
+    backgroundRed.dispose();
+    backgroundGreen.dispose();
+    edits.forEach(this::disposeEditUi);
+    viewer.getTextWidget().setLineSpacingProvider(null);
+    viewerExtension.setCodeMiningProviders(new ICodeMiningProvider[] {});
+  }
+
+  public void addEdit(FileEdit edit) {
+    edits.add(edit);
+    viewerExtension.updateCodeMinings();
+  }
+
+  private CompletableFuture<FileEditUi> createUi(FileEdit edit) {
+    return CompletableFuture.supplyAsync(
+        () -> {
+          try {
+            var document = state.getDocument();
+            var startLine = document.getLineOfOffset(edit.offset);
+            var endLine = document.getLineOfOffset(edit.offset + edit.length);
+
+            // Skip empty lines at the beginning of the edit. Eclipse is misbehaving if we try to
+            // attach minings to them.
+            while (document.get(document.getLineOffset(startLine), 1).matches("[\\n\\r]")) {
+              startLine++;
+            }
+
+            var startOffset = document.getLineOffset(startLine);
+            var afterEndOffset = document.getLineOffset(endLine);
+
+            var position = new Position(startOffset, 1);
+            var endPosition = new Position(afterEndOffset, 1);
+
+            var cleanedText =
+                edit.text
+                    .lines()
+                    .dropWhile(String::isBlank)
+                    .collect(Collectors.joining("\n"))
+                    .stripTrailing();
+            var lines = (int) cleanedText.lines().count();
+            lineSpacings.put(endLine - 1, lines);
+
+            StyleRange range = new StyleRange();
+            Display.getDefault()
+                .asyncExec(
+                    () -> {
+                      range.start = startOffset;
+                      range.length = afterEndOffset - startOffset;
+                      range.background = backgroundRed;
+                      viewer.getTextWidget().setStyleRange(range);
+                    });
+
+            var minings =
+                List.of(
+                    createIconMining(position, manager.codyIcon),
+                    createButtonMining(position, "Accept", e -> accept(edit)),
+                    createButtonMining(position, "Reject", e -> reject(edit)),
+                    createAdded(endPosition, cleanedText, lines));
+
+            // We are rejecting edits of the part marked for removal, because it is easier than
+            // keeping track of ranges during editing. If we want to change that in the future, we
+            // can use `viewer.getDocument().addPosition(...)`
+            VerifyListener listener =
+                e -> {
+                  // check if manualy edited range overlaps with a range of auto-edit. +1 to catch
+                  // the `\n`.
+                  if (e.end > edit.offset && e.start < edit.offset + edit.length + 1) {
+                    e.doit = false;
+                  }
+                };
+
+            Display.getDefault()
+                .asyncExec(() -> viewer.getTextWidget().addVerifyListener(listener));
+
+            return new FileEditUi(minings, endLine - 1, listener, range);
+          } catch (BadLocationException e) {
+            throw new WrappedRuntimeException(e);
+          }
+        });
+  }
+
+  private ICodeMining createButtonMining(
+      Position position, String text, Consumer<MouseEvent> action) {
+    try {
+      var mining = new LineHeaderCodeMining(position, this, action) {};
+      mining.setLabel(text);
+      return mining;
+    } catch (BadLocationException e) {
+      throw new WrappedRuntimeException(e);
+    }
+  }
+
+  private ICodeMining createIconMining(Position position, Image image) {
+    try {
+      var mining =
+          new LineHeaderCodeMining(position, this, null) {
+            @Override
+            public Point draw(GC gc, StyledText textWidget, Color color, int x, int y) {
+              gc.drawImage(image, x, y);
+              var bounds = image.getBounds();
+              return new Point(bounds.x + bounds.width, bounds.y + bounds.height);
+            }
+          };
+
+      // Shouldn't be visible anywhere in the UI. It is needed because minings without a label are
+      // invalid.
+      mining.setLabel("icon");
+      return mining;
+    } catch (BadLocationException e) {
+      throw new WrappedRuntimeException(e);
+    }
+  }
+
+  private ICodeMining createAdded(Position endPosition, String text, int addedLines) {
+    var mining =
+        new AbstractCodeMining(endPosition, this, null) {
+          @Override
+          public Point draw(GC gc, StyledText textWidget, Color color, int x, int y) {
+            var lineHeight = textWidget.getLineHeight();
+
+            gc.setBackground(backgroundGreen);
+
+            // Uncommenting lines below will color the entire added line. It looks
+            // better, but I wasn't able to replicate the effect for removed lines, so leaving it
+            // out for the sake of consistency.
+
+            // var width = textWidget.getBounds().width;
+            // var height = lineHeight * addedLines;
+            // gc.fillRectangle(0, y - lineHeight, width, height);
+
+            gc.drawText(text, textWidget.getLeftMargin(), y - addedLines * lineHeight);
+
+            // This annotation is not taking any space from the editor (line spacing already handles
+            // that)
+            return new Point(0, 0);
+          }
+        };
+    mining.setLabel("removed");
+    return mining;
+  }
+
+  private void accept(FileEdit edit) {
+    try {
+      state.getDocument().replace(edit.offset, edit.length, edit.text);
+      disposeEditUi(edit);
+    } catch (BadLocationException e) {
+      throw new WrappedRuntimeException(e);
+    }
+  }
+
+  private void reject(FileEdit edit) {
+    disposeEditUi(edit);
+  }
+
+  private void disposeEditUi(FileEdit edit) {
+    var editUi = cache.remove(edit).join();
+    lineSpacings.remove(editUi.shiftedLine);
+    edits.remove(edit);
+    viewer.getTextWidget().removeVerifyListener(editUi.verifyListener);
+
+    // Reset style of the range. Styled ranges without setting overrides are garbage collected.
+    var range = editUi.range;
+    range.background = null;
+    range.foreground = null;
+    viewer.getTextWidget().setStyleRange(range);
+
+    viewerExtension.updateCodeMinings();
+  }
+
+  private static class FileEditUi {
+    final List<ICodeMining> minings;
+    final int shiftedLine;
+    final VerifyListener verifyListener;
+    final StyleRange range;
+
+    FileEditUi(
+        List<ICodeMining> minings,
+        int shiftedLine,
+        VerifyListener verifyListener,
+        StyleRange range) {
+      this.minings = minings;
+      this.shiftedLine = shiftedLine;
+      this.verifyListener = verifyListener;
+      this.range = range;
+    }
+  }
+}

--- a/plugins/cody-chat/src/com/sourcegraph/cody/workspace/CodyContentListener.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/workspace/CodyContentListener.java
@@ -1,6 +1,8 @@
 package com.sourcegraph.cody.workspace;
 
 import com.sourcegraph.cody.chat.agent.CodyAgent;
+import com.sourcegraph.cody.edits.FileEditManager;
+import java.lang.ref.WeakReference;
 import org.eclipse.jface.text.DocumentEvent;
 import org.eclipse.jface.text.IDocumentListener;
 import org.eclipse.swt.widgets.Display;
@@ -8,6 +10,8 @@ import org.eclipse.swt.widgets.Display;
 public class CodyContentListener implements CodyListener, IDocumentListener {
   private final CodyAgent agent;
   private final EditorState editorState;
+
+  private WeakReference<FileEditManager> fileEditManager;
 
   public CodyContentListener(CodyAgent agent, EditorState editorState) {
     this.agent = agent;
@@ -18,11 +22,20 @@ public class CodyContentListener implements CodyListener, IDocumentListener {
   public void install() {
     agent.fileOpened(editorState);
     editorState.getDocument().addDocumentListener(this);
+
+    var manager = new FileEditManager(editorState, agent.editManager);
+    fileEditManager = new WeakReference<FileEditManager>(manager);
+    manager.install();
   }
 
   @Override
   public void dispose() {
     Display.getDefault().execute(() -> editorState.getDocument().removeDocumentListener(this));
+
+    var manager = fileEditManager.get();
+    if (manager != null) {
+      manager.dispose();
+    }
   }
 
   @Override

--- a/plugins/cody-chat/src/com/sourcegraph/cody/workspace/LensDebugHandler.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/workspace/LensDebugHandler.java
@@ -1,0 +1,68 @@
+package com.sourcegraph.cody.workspace;
+
+import com.sourcegraph.cody.WrappedRuntimeException;
+import com.sourcegraph.cody.chat.agent.CodyManager;
+import com.sourcegraph.cody.edits.FileEdit;
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.ui.PlatformUI;
+
+public class LensDebugHandler extends AbstractHandler {
+
+  CodyManager manager = CodyManager.INSTANCE;
+
+  @Override
+  public Object execute(ExecutionEvent event) {
+    if (CodyManager.INSTANCE == null) {
+      MessageDialog.openError(
+          PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(),
+          "Error",
+          "First open the chat to make sure that agent is running.");
+    }
+
+    CodyManager.INSTANCE.withAgent(
+        a -> {
+          var editor =
+              PlatformUI.getWorkbench()
+                  .getActiveWorkbenchWindow()
+                  .getActivePage()
+                  .getActivePartReference();
+          var state = EditorState.from(editor);
+
+          if (state == null) {
+            MessageDialog.openError(
+                PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(),
+                "Error",
+                "No editor focused");
+            return;
+          }
+
+          var document = state.getDocument();
+
+          try {
+            var line3 = document.getLineOffset(3);
+            var line6 = document.getLineOffset(6);
+            var line9 = document.getLineOffset(9);
+            var line12 = document.getLineOffset(12);
+            a.editManager.addEdit(state.uri, toUpperCaseEdit(line3, line6 - line3, document));
+            a.editManager.addEdit(state.uri, toUpperCaseEdit(line9, line12 - line9, document));
+          } catch (BadLocationException e) {
+            throw new RuntimeException(e);
+          }
+        });
+
+    return null;
+  }
+
+  private FileEdit toUpperCaseEdit(int offset, int length, IDocument document) {
+    try {
+      String text = document.get(offset, length).toUpperCase();
+      return new FileEdit(offset, length, text);
+    } catch (BadLocationException e) {
+      throw new WrappedRuntimeException(e);
+    }
+  }
+}


### PR DESCRIPTION
The hard part of getting code edits. This PR also adds a temporary command for test purposes. It should be removed but can be later re-used as a part of an automated test.

It uses code minings, as they are the only way of drawing in the editor that will not interfere with other plugins that users may have installed.

## Test plan
- Open Cody Chat (to be sure that the agent is running)
- Open a file in the editor. It should contain at least 14 lines for the test to work correctly.
- Run the "Test Edits" command from the command palette(`Cmd + 3`)
- [ ] You should see two proposed edits.
- [ ] Line numbers should stay as they were before.
- Try to edit some text in the line with a red background
-  [ ] It shouldn't be possible
- Try to edit any text without any background.
- [ ] It should be possible.
- Reject one of edits.
- [ ] The edit UI should disappear completely
- Accept the other edit.
- [ ] The file content should be changed, and the edit UI should disappear.

## Current limitations
1. When edits are rejected, minor syntax coloring glitches may occur. Usually, they go away after a few seconds or any action that causes recoloring (e.g., clicking anywhere in the miss-colored line).
2. We only set a background for the text, not the whole lines. While this can be easily achieved for the added code (it is in the commented code in this pr), it seems not to be possible for the removed code. The reason for that is that for the removed part, we are using the text from the editor. While the underlying widget supports setting the background for the whole lines, the editor itself overrides that.
3. The Accept and Reject "buttons" must be created as separate minings, which causes Eclipse to add a separator between them. Eclipse treats whole minings as either clickable or not-clickable. We need to create separate minings to give users a visual hint (cursor shape) on what is clickable and what is not.
4. The blank lines from the beginning of the edited code are trimmed. This is because Eclipse is not able to attach minings to blank lines. It is not documented, but it was like this for many years, so now it is treated as a feature.

Limitations 1 and 2 can be overcome if we render the removed text the same way we currently render the added one. We would need to ensure that it is drawn over the existing text in the editor. While it is not hard to achieve, I kind of fear the visual glitches it may cause for some modified editors.