### PR TITLE
Created a temp dir if no projects are found on the file system

### DIFF
--- a/plugins/cody-chat/src/com/sourcegraph/cody/CodyPaths.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/CodyPaths.java
@@ -2,6 +2,7 @@ package com.sourcegraph.cody;
 
 import dev.dirs.ProjectDirectories;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -38,6 +39,11 @@ public class CodyPaths {
 
   public static Path dataDir() {
     return Paths.get(projectDirectories().dataDir);
+  }
+
+  public static Path tempDir() throws IOException {
+    // create a new temporary directory
+    return Files.createTempDirectory("temp-");
   }
 
   public static Path agentScript(CodyResources resources) throws IOException {

--- a/plugins/cody-chat/src/com/sourcegraph/cody/chat/agent/StartAgentJob.java
+++ b/plugins/cody-chat/src/com/sourcegraph/cody/chat/agent/StartAgentJob.java
@@ -160,18 +160,18 @@ public class StartAgentJob extends Job {
     server.initialized(null);
   }
 
-  private Path getWorkspaceRoot() throws URISyntaxException {
+  private Path getWorkspaceRoot() throws URISyntaxException, IOException {
     // Pick the first open project as the workspace root.
     for (var project : ResourcesPlugin.getWorkspace().getRoot().getProjects()) {
       if (project.isOpen()) {
-        return project.getLocation().toFile().toPath();
+        var path = project.getLocation();
+        if (path != null) {
+          return path.toFile().toPath();
+        }
       }
     }
 
-    // This path is 100% wrong. The main problem with workspace root in Eclipse is that
-    // it's common to have multiple projects with different workspace roots. The agent server
-    // doesn't support multi-root workspaces at this time.
-    return Paths.get(Platform.getInstanceLocation().getURL().toURI());
+    return CodyPaths.tempDir();
   }
 
   private void configureGson(GsonBuilder builder) {


### PR DESCRIPTION
This is an attempt to resolve issues for Semantic file system users, where we just create and return a temp dir if none of the project file systems are on disk. However, I can't test this because I can't create an ABAP project.

## Test plan
Very open ended right now.

<!-- Required. See https://docs-legacy.sourcegraph.com/dev/background-information/testing_principles. -->
